### PR TITLE
feat(web): gate public web app behind static 'coming soon' screen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,19 @@ REACT_APP_FIREBASE_APP_ID=your_app_id_here
 # REACT_APP_USE_EMULATORS=false
 
 # ==========================================
+# WEB GATE ("coming soon")
+# ==========================================
+# When 'true', the web app renders a static placeholder ABOVE all routing,
+# auth, and Firebase (no login/signup/Firestore reachable). Used to gate the
+# hosted web app until web PMF is validated.
+#   - Production (static Hosting, local build): set REACT_APP_WEB_GATED=true
+#     in .env.production.local (gitignored)
+#   - Production (Firebase App Hosting, cloud build): set in apphosting.yaml
+#     env (committed) — gitignored .env files are absent in cloud builds
+#   - Local dev (npm start): leave unset to run the full app
+# REACT_APP_WEB_GATED=false
+
+# ==========================================
 # NOTES
 # ==========================================
 #

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -1,0 +1,15 @@
+# Firebase App Hosting configuration
+# https://firebase.google.com/docs/app-hosting/configure
+#
+# Web gate ("coming soon"): keep REACT_APP_WEB_GATED=true here so the gate
+# also activates when the web app is built in the cloud by Firebase App
+# Hosting (gitignored .env.production.local is NOT present in cloud builds).
+# This mirrors the value in .env.production.local used by local static builds.
+#
+# REVERT AT PUBLIC WEB LAUNCH: set value to "false" (or remove this env entry).
+env:
+  - variable: REACT_APP_WEB_GATED
+    value: "true"
+    availability:
+      - BUILD
+      - RUNTIME

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Web app is gated (coming soon) until web PMF is validated. Keep search
+         engines out while gated; remove this line at public web launch. -->
+    <meta name="robots" content="noindex,nofollow" />
     <meta name="theme-color" content="#1B5E57" />
     <meta
       name="description"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
+# Web app is gated (coming soon) until web PMF is validated.
+# Disallow all crawling while gated; revert to "Disallow:" at public launch.
 User-agent: *
-Disallow:
+Disallow: /

--- a/src/components/WebComingSoon.jsx
+++ b/src/components/WebComingSoon.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+/**
+ * WebComingSoon
+ *
+ * Static, on-brand placeholder shown on the public web app while it is gated
+ * (REACT_APP_WEB_GATED === 'true'). It is rendered ABOVE all routing, auth,
+ * and Firebase (see src/index.js): when gated, the app/auth/Firestore module
+ * tree is never imported, so nothing below this screen can execute.
+ *
+ * Styles are intentionally self-contained inline styles (no Tailwind / app CSS
+ * dependency) so the screen renders identically regardless of app state. Inter
+ * is already loaded by public/index.html. Reversible: flip the flag.
+ */
+
+const MIST_WHITE = '#FAFAF6';
+const EVERGREEN_TEAL = '#1B5E57';
+const FONT_STACK =
+  "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
+
+export default function WebComingSoon() {
+  return (
+    <main
+      style={{
+        minHeight: '100vh',
+        width: '100%',
+        boxSizing: 'border-box',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: MIST_WHITE,
+        color: EVERGREEN_TEAL,
+        fontFamily: FONT_STACK,
+        padding: '32px 24px',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ maxWidth: '34rem', width: '100%' }}>
+        <p
+          style={{
+            margin: '0 0 3rem',
+            fontSize: '0.8125rem',
+            fontWeight: 600,
+            letterSpacing: '0.2em',
+            textTransform: 'uppercase',
+            opacity: 0.65,
+          }}
+        >
+          Vara
+        </p>
+
+        <h1
+          style={{
+            margin: '0 0 1.5rem',
+            fontSize: 'clamp(1.75rem, 4.5vw, 2.5rem)',
+            fontWeight: 600,
+            lineHeight: 1.2,
+            letterSpacing: '-0.01em',
+          }}
+        >
+          Vara is coming to the web.
+        </h1>
+
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'clamp(1rem, 2.2vw, 1.125rem)',
+            fontWeight: 400,
+            lineHeight: 1.7,
+            opacity: 0.85,
+          }}
+        >
+          Right now, Vara lives on iOS — a calmer way to recover from stress and
+          support how your brain handles it. The web experience is on its way.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,33 +1,71 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
-import { BrowserRouter } from 'react-router-dom';
-import { AuthProvider } from './context/AuthContext';
-import { ToastProvider } from './context/ToastContext';
-import ErrorBoundary from './components/ErrorBoundary';
+
+// ---------------------------------------------------------------------------
+// Web gate (top-level, above routing/auth/Firebase)
+// ---------------------------------------------------------------------------
+// Until web PMF is validated, public visits to the hosted web app show a
+// static, on-brand "coming soon" screen. The gate short-circuits ABOVE the
+// router, auth, and Firebase: when ON, the app tree is never imported, so
+// src/firebase.js (which calls initializeApp() at module load), the auth
+// listener, signup, and all Firestore access are unreachable — no route can
+// bypass it because no route is loaded at all.
+//
+// Controlled by REACT_APP_WEB_GATED (CRA bakes this in at build time):
+//   - production build : set 'true' in .env.production.local  -> gated screen
+//   - local dev / npm start : unset                           -> full app
+//
+// Reversible: flip the flag, rebuild, redeploy. No app/route/data code is
+// modified by this gate.
+// ---------------------------------------------------------------------------
+const WEB_GATED = process.env.REACT_APP_WEB_GATED === 'true';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 
-root.render(
-  <React.StrictMode>
-    <ErrorBoundary level="root">
-      <BrowserRouter>
-        <ToastProvider>
-          <AuthProvider>
-            <App />
-          </AuthProvider>
-        </ToastProvider>
-      </BrowserRouter>
-    </ErrorBoundary>
-  </React.StrictMode>
-);
+if (WEB_GATED) {
+  // Gated: load ONLY the static placeholder. Nothing else enters the graph.
+  import('./components/WebComingSoon').then(({ default: WebComingSoon }) => {
+    root.render(
+      <React.StrictMode>
+        <WebComingSoon />
+      </React.StrictMode>
+    );
+  });
+} else {
+  // Full app. Dynamic imports keep the app/auth/Firebase modules out of the
+  // bundle path that runs when gated above.
+  Promise.all([
+    import('./App'),
+    import('react-router-dom'),
+    import('./context/AuthContext'),
+    import('./context/ToastContext'),
+    import('./components/ErrorBoundary'),
+    import('./reportWebVitals'),
+  ]).then(
+    ([
+      { default: App },
+      { BrowserRouter },
+      { AuthProvider },
+      { ToastProvider },
+      { default: ErrorBoundary },
+      { default: reportWebVitals },
+    ]) => {
+      root.render(
+        <React.StrictMode>
+          <ErrorBoundary level="root">
+            <BrowserRouter>
+              <ToastProvider>
+                <AuthProvider>
+                  <App />
+                </AuthProvider>
+              </ToastProvider>
+            </BrowserRouter>
+          </ErrorBoundary>
+        </React.StrictMode>
+      );
 
-reportWebVitals();
-
-
-
-
-
-
+      reportWebVitals();
+    }
+  );
+}


### PR DESCRIPTION
## What
Gates the public web app behind a static, on-brand "coming soon" screen until web PMF is validated. Fully additive and reversible via an env flag.

## How it works
- `REACT_APP_WEB_GATED` checked at the **routing root** (`src/index.js`), **above** router/auth/Firebase.
- When gated, the app/auth/Firebase tree is **never imported** (dynamic `import()`), so no route, auth listener, signup, or Firestore access is reachable. `src/firebase.js` calls `initializeApp()` at module load, so avoiding the import — not just the render — is what makes this airtight.
- New `WebComingSoon` placeholder: Mist White `#FAFAF6`, Evergreen Teal `#1B5E57`, Inter, self-contained inline styles.
- `noindex,nofollow` meta + `robots.txt` `Disallow: /`.

## Flag is set in BOTH places (correct under either deploy path)
- `.env.production.local` (gitignored) — local static `firebase deploy --only hosting` builds.
- `apphosting.yaml` (committed) — Firebase App Hosting cloud builds, where gitignored `.env` files are absent.
- Local dev (`npm start`) leaves it unset → full app runs.

## Verification
- Production build succeeds; entry `main.js` dropped ~460 KB (app code split into lazy chunks).
- Entry chunk contains **zero** Firebase/auth markers (`initializeApp`, `onAuthStateChanged`, etc.); those live only in lazy chunks the gate never requests.
- Routes `/`, `/login`, `/signup`, `/onboarding/welcome`, `/dashboard`, `/community`, `/journal` all render the gated screen (`/` and `/login` byte-identical screenshots).

## ⚠️ Revert at public web launch
- `public/index.html` — remove `noindex` meta
- `public/robots.txt` — restore `Disallow:`
- `REACT_APP_WEB_GATED` — set `false`/remove in `.env.production.local` **and** `apphosting.yaml`

## Note
If Firebase **App Hosting** is the live path and watches `main`, **merging this PR will auto-trigger a production deploy.** Deploy-path confirmation via `firebase apphosting:backends:list` is pending CLI reauth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)