### PR TITLE
fix(onboarding): valence-branch driver question + Reflect framing (positive-state coherence)

### DIFF
--- a/mobile/src/constants/onboardingStressRecovery.ts
+++ b/mobile/src/constants/onboardingStressRecovery.ts
@@ -74,7 +74,7 @@ const POSITIVE_DRIVER_STATES: readonly BrainState[] = ['steady', 'clear', 'alive
 
 export type DriverValence = 'activated' | 'positive';
 
-export function driverValenceForState(state: BrainState | undefined): DriverValence {
+export function driverValenceForState(state: BrainState | null | undefined): DriverValence {
   return state && POSITIVE_DRIVER_STATES.includes(state) ? 'positive' : 'activated';
 }
 
@@ -95,14 +95,25 @@ export function getDriverQuestion(state: BrainState | undefined): DriverQuestion
 }
 
 /**
- * Union of all driver options across valences. Used ONLY for id -> label
- * resolution (e.g. the Reflect snapshot rebuilt from persisted ids on resume),
- * never for display. Kept under the legacy name so existing id->label callers
- * resolve both valences without change.
+ * Drivers retired from display but kept for id -> label resolution, so retained
+ * accounts that persisted them before removal still render a label on the
+ * Reflect snapshot. NEVER part of a selectable option set.
+ */
+const RETIRED_DRIVER_OPTIONS: DriverOption[] = [
+  { id: 'foggy_scattered', label: 'Foggy and scattered' },
+];
+
+/**
+ * Union of all driver options across valences, plus retired ids. Used ONLY for
+ * id -> label resolution (e.g. the Reflect snapshot rebuilt from persisted ids
+ * on resume), NEVER for display. Display uses the valence-specific lists via
+ * getDriverQuestion. Kept under the legacy name so existing id->label callers
+ * resolve every valence (and retired ids) without change.
  */
 export const STRESSOR_OPTIONS: DriverOption[] = [
   ...ACTIVATED_DRIVER_OPTIONS,
   ...POSITIVE_DRIVER_OPTIONS,
+  ...RETIRED_DRIVER_OPTIONS,
 ];
 
 /** Screen 4 — "when it peaks" (skippable). Feeds the anchor suggestion. */

--- a/mobile/src/constants/onboardingStressRecovery.ts
+++ b/mobile/src/constants/onboardingStressRecovery.ts
@@ -37,13 +37,72 @@ export function onboardingStepNumber(step: OnboardingSrStep): number {
 
 export type PeakWindow = 'morning' | 'midday' | 'evening';
 
-/** Screen 3 — "what's driving it" (skippable). Stress-framed, plain language. */
-export const STRESSOR_OPTIONS: { id: string; label: string }[] = [
+/**
+ * Screen 3 — driver selection (skippable, multi-select). The stem and option set
+ * branch on the VALENCE of the brain state picked on screen 2:
+ *   - Activated states (Wired, Foggy): "What's driving it?" — stress drivers.
+ *   - Positive states (Steady, Clear, Alive): "What's behind it?" — supports.
+ * Options are persisted as stable ids (onboardingStressRecovery.stressors:
+ * string[]). Ids are unique across both sets, so the stored shape is unchanged.
+ */
+export interface DriverOption {
+  id: string;
+  label: string;
+}
+
+/** Activated valence (Wired, Foggy). The prior stress list, plus "stretched too thin"; "Foggy and scattered" removed. */
+export const ACTIVATED_DRIVER_OPTIONS: DriverOption[] = [
   { id: 'racing_mind', label: 'A racing mind' },
   { id: 'cant_switch_off', label: "Can't switch off after work" },
-  { id: 'foggy_scattered', label: 'Foggy and scattered' },
+  { id: 'stretched_too_thin', label: 'Stretched too thin' },
   { id: 'cant_wind_down', label: "Can't wind down for sleep" },
   { id: 'feeling_reactive', label: 'Feeling reactive' },
+];
+
+/** Positive valence (Steady, Clear, Alive). What's supporting the good state. */
+export const POSITIVE_DRIVER_OPTIONS: DriverOption[] = [
+  { id: 'good_nights_sleep', label: "A good night's sleep" },
+  { id: 'movement_fresh_air', label: 'Some movement or fresh air' },
+  { id: 'lighter_day', label: 'A lighter day than usual' },
+  { id: 'connection', label: 'Connection with someone' },
+  { id: 'slow_down', label: 'Time to slow down' },
+  { id: 'not_sure', label: 'Not sure, it just feels this way' },
+];
+
+/** Brain states treated as positive valence for the driver question. */
+const POSITIVE_DRIVER_STATES: readonly BrainState[] = ['steady', 'clear', 'alive'];
+
+export type DriverValence = 'activated' | 'positive';
+
+export function driverValenceForState(state: BrainState | undefined): DriverValence {
+  return state && POSITIVE_DRIVER_STATES.includes(state) ? 'positive' : 'activated';
+}
+
+export interface DriverQuestion {
+  stem: string;
+  options: DriverOption[];
+}
+
+/**
+ * Stem + option set for the driver screen, branched by state valence. Unknown or
+ * missing state defaults to the activated set, matching DEFAULT_ONBOARDING_STATE
+ * ('wired') and the prior always-stress behavior on a lost resume param.
+ */
+export function getDriverQuestion(state: BrainState | undefined): DriverQuestion {
+  return driverValenceForState(state) === 'positive'
+    ? { stem: "What's behind it?", options: POSITIVE_DRIVER_OPTIONS }
+    : { stem: "What's driving it?", options: ACTIVATED_DRIVER_OPTIONS };
+}
+
+/**
+ * Union of all driver options across valences. Used ONLY for id -> label
+ * resolution (e.g. the Reflect snapshot rebuilt from persisted ids on resume),
+ * never for display. Kept under the legacy name so existing id->label callers
+ * resolve both valences without change.
+ */
+export const STRESSOR_OPTIONS: DriverOption[] = [
+  ...ACTIVATED_DRIVER_OPTIONS,
+  ...POSITIVE_DRIVER_OPTIONS,
 ];
 
 /** Screen 4 — "when it peaks" (skippable). Feeds the anchor suggestion. */

--- a/mobile/src/screens/onboarding/OnboardingReflectScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingReflectScreen.tsx
@@ -17,6 +17,7 @@ import {
   type PeakWindow,
   ONBOARDING_SR_TOTAL_STEPS,
   onboardingStepNumber,
+  driverValenceForState,
 } from '../../constants/onboardingStressRecovery';
 import { useAuth } from '../../context/AuthContext';
 import { saveOnboardingStep } from '../../services/firebase/onboardingStressRecovery.service';
@@ -147,13 +148,20 @@ const OnboardingReflectScreen: React.FC = () => {
   // doesn't get. Falls back to a generic phrase when state is unresolved.
   const resetLine = useMemo(() => onboardingResetLine(resolved.state), [resolved.state]);
 
+  // Primary CTA branches with the lead-in: positive states "Begin", activated
+  // (and default) keep "Start the reset". Same valence helper as the lead-in.
+  const primaryLabel = useMemo(
+    () => (driverValenceForState(resolved.state) === 'positive' ? 'Begin' : 'Start the reset'),
+    [resolved.state]
+  );
+
   return (
     <OnboardingScaffold
       currentStep={onboardingStepNumber('OnboardingReflect')}
       totalSteps={ONBOARDING_SR_TOTAL_STEPS}
       centerContent
       title="Here's where you're starting."
-      primaryLabel="Start the reset"
+      primaryLabel={primaryLabel}
       onPrimary={() => navigation.navigate('OnboardingProtocol', { state: resolved.state })}
       onBack={navigation.canGoBack() ? () => navigation.goBack() : undefined}
     >

--- a/mobile/src/screens/onboarding/OnboardingStressorScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingStressorScreen.tsx
@@ -1,15 +1,30 @@
 /**
- * Screen 3 — "What's driving it" (skippable, multi-select). Stress-framed
- * options; selections are persisted for personalization/analytics. Skip writes
- * an empty selection with no penalty copy.
+ * Screen 3 — driver selection (skippable, multi-select). The stem and options
+ * branch on the valence of the state picked on screen 2 (activated -> "What's
+ * driving it?" stress drivers; positive -> "What's behind it?" supports), via
+ * getDriverQuestion. Selections persist as ids for personalization/analytics;
+ * an empty selection (skip) writes [] with no penalty copy.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { View } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { Wind, Briefcase, CloudFog, Moon, Flame, type LucideIcon } from 'lucide-react-native';
+import {
+  Wind,
+  Briefcase,
+  Moon,
+  Flame,
+  Gauge,
+  Leaf,
+  Sun,
+  Users,
+  Coffee,
+  Sparkles,
+  type LucideIcon,
+} from 'lucide-react-native';
 import { OnboardingScaffold } from '../../components/onboarding/OnboardingScaffold';
 import { SelectionRow } from '../../components/onboarding/SelectionRow';
 import {
+  getDriverQuestion,
   STRESSOR_OPTIONS,
   ONBOARDING_SR_TOTAL_STEPS,
   onboardingStepNumber,
@@ -21,13 +36,24 @@ import {
 } from '../../services/firebase/onboardingStressRecovery.service';
 import type { BrainState } from '../../types/models';
 
-// Line icon per stressor option (keyed by stable id, not label).
-const STRESSOR_ICONS: Record<string, LucideIcon> = {
+// Line icon per driver option (keyed by stable id, not label). Covers both
+// valence sets; the two sets never render together, so a shared sleep icon
+// (Moon) for activated "can't wind down" and positive "good night's sleep" is
+// fine.
+const DRIVER_ICONS: Record<string, LucideIcon> = {
+  // Activated (Wired, Foggy)
   racing_mind: Wind,
   cant_switch_off: Briefcase,
-  foggy_scattered: CloudFog,
+  stretched_too_thin: Gauge,
   cant_wind_down: Moon,
   feeling_reactive: Flame,
+  // Positive (Steady, Clear, Alive)
+  good_nights_sleep: Moon,
+  movement_fresh_air: Leaf,
+  lighter_day: Sun,
+  connection: Users,
+  slow_down: Coffee,
+  not_sure: Sparkles,
 };
 
 const OnboardingStressorScreen: React.FC = () => {
@@ -36,6 +62,8 @@ const OnboardingStressorScreen: React.FC = () => {
   const { user } = useAuth();
   const state: BrainState | undefined = route.params?.state;
   const [selected, setSelected] = useState<string[]>([]);
+  // Stem + options branch on the valence of the selected state.
+  const { stem, options } = useMemo(() => getDriverQuestion(state), [state]);
 
   useEffect(() => {
     if (user?.uid) void saveOnboardingStep(user.uid, 'OnboardingStressor');
@@ -60,18 +88,18 @@ const OnboardingStressorScreen: React.FC = () => {
     <OnboardingScaffold
       currentStep={onboardingStepNumber('OnboardingStressor')}
       totalSteps={ONBOARDING_SR_TOTAL_STEPS}
-      title="What's driving it?"
+      title={stem}
       subtitle="Pick any that fit, or skip."
       primaryLabel="Continue"
       onPrimary={() => advance(selected)}
       onBack={navigation.canGoBack() ? () => navigation.goBack() : undefined}
     >
       <View>
-        {STRESSOR_OPTIONS.map((opt) => (
+        {options.map((opt) => (
           <SelectionRow
             key={opt.id}
             label={opt.label}
-            icon={STRESSOR_ICONS[opt.id]}
+            icon={DRIVER_ICONS[opt.id]}
             selectionMode="multi"
             selected={selected.includes(opt.id)}
             onPress={() => toggle(opt.id)}

--- a/mobile/src/screens/onboarding/__tests__/OnboardingBackNav.integration.test.tsx
+++ b/mobile/src/screens/onboarding/__tests__/OnboardingBackNav.integration.test.tsx
@@ -71,7 +71,10 @@ function renderFlow() {
 const pressLast = (els: any[]) => fireEvent.press(els[els.length - 1]);
 
 const ARRIVAL = 'How are you arriving right now?';
-const DRIVERS = "What's driving it?";
+// These tests select Steady (positive valence), so the driver screen shows the
+// positive stem + options (see getDriverQuestion).
+const DRIVERS = "What's behind it?";
+const POSITIVE_DRIVER = "A good night's sleep";
 const PEAK = 'When does it peak?';
 const REFLECT = "Here's where you're starting.";
 
@@ -122,15 +125,15 @@ describe('Onboarding pre-protocol back navigation', () => {
     pressLast(getAllByLabelText('Continue'));
     await findByText(DRIVERS);
 
-    fireEvent.press(getByLabelText('A racing mind'));
-    expect(getByLabelText('A racing mind').props.accessibilityState.checked).toBe(true);
+    fireEvent.press(getByLabelText(POSITIVE_DRIVER));
+    expect(getByLabelText(POSITIVE_DRIVER).props.accessibilityState.checked).toBe(true);
 
     pressLast(getAllByLabelText('Continue'));
     await findByText(PEAK);
 
     pressLast(getAllByLabelText('Go back'));
     await findByText(DRIVERS);
-    expect(getByLabelText('A racing mind').props.accessibilityState.checked).toBe(true);
+    expect(getByLabelText(POSITIVE_DRIVER).props.accessibilityState.checked).toBe(true);
   });
 
   test('back from the starting-point transition preserves the peak selection', async () => {

--- a/mobile/src/screens/onboarding/__tests__/OnboardingReflectScreen.test.tsx
+++ b/mobile/src/screens/onboarding/__tests__/OnboardingReflectScreen.test.tsx
@@ -100,11 +100,11 @@ describe('OnboardingReflectScreen snapshot card', () => {
     ).toBeTruthy();
   });
 
-  it('names the actual duration when the protocol resolves to 5 minutes (Steady → Coherence Breathing)', () => {
+  it('names the actual duration with positive-valence copy (Steady → Coherence Breathing, 5 min)', () => {
     mockParams = { state: 'steady', stressorLabels: [], peak: null };
     const { getByText } = render(<OnboardingReflectScreen />);
     expect(
-      getByText("Here's a five-minute reset to help your system downshift.")
+      getByText("Here's a five-minute practice to help you stay with this.")
     ).toBeTruthy();
   });
 

--- a/mobile/src/screens/onboarding/resolveOnboardingProtocol.ts
+++ b/mobile/src/screens/onboarding/resolveOnboardingProtocol.ts
@@ -16,6 +16,7 @@ import {
   ONBOARDING_ENTRY_PROTOCOL_OVERRIDES,
   ONBOARDING_PROTOCOL_TIME_WINDOW,
   DEFAULT_ONBOARDING_PROTOCOL_ID,
+  driverValenceForState,
 } from '../../constants/onboardingStressRecovery';
 
 export function resolveOnboardingProtocol(state: BrainState): Protocol | null {
@@ -56,16 +57,24 @@ export function minutesWord(durationSeconds: number): string {
 }
 
 /**
- * The "Here's a {duration} reset…" lead-in on the Reflect screen, sized to the
- * actually-selected protocol. Falls back to a generic phrase when the state or
- * the protocol's duration can't be resolved (rather than rendering a wrong or
+ * The "Here's a {duration} …" lead-in on the Reflect screen, sized to the
+ * actually-selected protocol and branched by state valence (shared helper):
+ *   - Activated (Wired, Foggy) / default: "...reset to help your system downshift."
+ *   - Positive (Steady, Clear, Alive):    "...practice to help you stay with this."
+ * Falls back to a generic phrase (same valence split) when the state or the
+ * protocol's duration can't be resolved (rather than rendering a wrong or
  * "{undefined}-minute" string).
  */
 export function onboardingResetLine(state: BrainState | null): string {
   const protocol = state ? resolveOnboardingProtocol(state) : null;
   const seconds = protocol?.durationSeconds;
+  const positive = driverValenceForState(state) === 'positive';
   if (!seconds || seconds <= 0) {
-    return "Here's a short reset to help your system downshift.";
+    return positive
+      ? "Here's a short practice to help you stay with this."
+      : "Here's a short reset to help your system downshift.";
   }
-  return `Here's a ${minutesWord(seconds)}-minute reset to help your system downshift.`;
+  return positive
+    ? `Here's a ${minutesWord(seconds)}-minute practice to help you stay with this.`
+    : `Here's a ${minutesWord(seconds)}-minute reset to help your system downshift.`;
 }


### PR DESCRIPTION
Makes stress-recovery onboarding coherent for **positive** brain states (Steady, Clear, Alive), which previously saw stress-only copy. Two commits, scoped to copy + conditionals; **no protocol-selection, layout, token, motion, or flow changes**.

## Commit 1 — driver question by valence (`0f06c56`)
The driver screen showed a fixed `What's driving it?` stem with stress-symptom options regardless of state. `getDriverQuestion(state)` now branches on valence (`driverValenceForState`):
- **Activated** (Wired, Foggy / default): `What's driving it?` + stress drivers (added `stretched_too_thin`, removed `foggy_scattered` from display).
- **Positive** (Steady, Clear, Alive): `What's behind it?` + support-oriented options.

Maps by canonical `BrainState` ids; applied via the shared component so all entry points inherit it. Persistence unchanged (`onboardingStressRecovery.stressors`: string[] of ids).

## Commit 2 — Reflect framing + back-compat (`d83e857`)
- Reflect lead-in (`onboardingResetLine`) + primary button branch via the **same** `driverValenceForState` helper:
  - Positive: `Here's a {n}-minute practice to help you stay with this.` / button `Begin`
  - Activated/default: `Here's a {n}-minute reset to help your system downshift.` / button `Start the reset` (byte-for-byte unchanged)
  - `{n}`-minute interpolation preserved; no-duration fallback mirrored per valence.
- Back-compat: `RETIRED_DRIVER_OPTIONS` (`foggy_scattered` -> `Foggy and scattered`) added to the `STRESSOR_OPTIONS` **union for id->label resolution only**, so retained accounts still render a label on the Reflect snapshot. The selectable list is built from `getDriverQuestion`, never the union, so the retired id can never render as a pickable chip.

## Notes
- Protocol selection deliberately **untouched** — already state-appropriate (Steady/Clear -> Coherence Breathing, Alive -> Light Movement).
- `OnboardingRecheck` re-runs the 5-state check-in only; it has no driver/stressor question, so no parallel valence mismatch.
- No em/en dashes in user-facing copy.

## Verification
- Onboarding + service tests: 50 passing / 6 suites (updated the Steady Reflect + back-nav positive-path assertions).
- TypeScript: frozen baseline unchanged at 180 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)