### PR TITLE
fix(onboarding): valence coherence across the V2 stress-recovery flow

### DIFF
--- a/mobile/src/screens/onboarding/OnboardingAnchorScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingAnchorScreen.tsx
@@ -17,7 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, Platform } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import { useNavigation } from '@react-navigation/native';
+import { useRoute } from '@react-navigation/native';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../../config/firebase';
 import { OnboardingScaffold } from '../../components/onboarding/OnboardingScaffold';
@@ -28,7 +28,9 @@ import {
   type PeakWindow,
   ONBOARDING_SR_TOTAL_STEPS,
   onboardingStepNumber,
+  driverValenceForState,
 } from '../../constants/onboardingStressRecovery';
+import type { BrainState } from '../../types/models';
 import { useAuth } from '../../context/AuthContext';
 import {
   saveOnboardingStep,
@@ -51,8 +53,14 @@ function hourForPeak(peak: PeakWindow | null): number {
 }
 
 const OnboardingAnchorScreen: React.FC = () => {
-  const navigation = useNavigation<any>();
+  const route = useRoute<any>();
   const { user } = useAuth();
+  const state: BrainState | undefined = route.params?.state;
+  // Positive arrivals reframe "reset" as a neutral "check in". Unknown → activated.
+  const anchorTitle =
+    driverValenceForState(state) === 'positive'
+      ? 'Want a daily moment to check in?'
+      : 'Want a daily moment to reset?';
   const [selectedTime, setSelectedTime] = useState(new Date(2024, 0, 1, DEFAULT_ANCHOR_HOUR, 0));
   const [showPicker, setShowPicker] = useState(Platform.OS === 'ios');
   const [busy, setBusy] = useState(false);
@@ -146,7 +154,7 @@ const OnboardingAnchorScreen: React.FC = () => {
     <OnboardingScaffold
       currentStep={onboardingStepNumber('OnboardingAnchor')}
       totalSteps={ONBOARDING_SR_TOTAL_STEPS}
-      title="Want a daily moment to reset?"
+      title={anchorTitle}
       subtitle="Pick a time that fits your day. It's an invitation, not an obligation. You can change or turn it off anytime."
       primaryLabel="Continue"
       primaryDisabled={busy}

--- a/mobile/src/screens/onboarding/OnboardingBridgeScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingBridgeScreen.tsx
@@ -6,20 +6,34 @@
  */
 import React, { useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import { Repeat } from 'lucide-react-native';
 import { OnboardingScaffold } from '../../components/onboarding/OnboardingScaffold';
 import { Colors, Spacing, Typography, Layout } from '../../constants';
 import {
   ONBOARDING_SR_TOTAL_STEPS,
   onboardingStepNumber,
+  driverValenceForState,
 } from '../../constants/onboardingStressRecovery';
 import { useAuth } from '../../context/AuthContext';
 import { saveOnboardingStep } from '../../services/firebase/onboardingStressRecovery.service';
+import type { BrainState } from '../../types/models';
 
 const OnboardingBridgeScreen: React.FC = () => {
   const navigation = useNavigation<any>();
+  const route = useRoute<any>();
   const { user } = useAuth();
+  const state: BrainState | undefined = route.params?.state;
+
+  // "reset" reads wrong for a positive arrival who did a "practice"; branch the
+  // framing on initial-state valence (single source). Unknown → activated.
+  const positive = driverValenceForState(state) === 'positive';
+  const title = positive
+    ? 'One practice is a start. The change is in the repetition.'
+    : 'One reset is a start. The change is in the repetition.';
+  const cardText = positive
+    ? "What you felt was a single moment. The change comes from repetition. Give it two weeks and you'll feel the difference between a one-off and a pattern."
+    : "What you felt was a single reset. The change comes from repetition. Give it two weeks and you'll feel the difference between a one-off and a pattern.";
 
   useEffect(() => {
     if (user?.uid) void saveOnboardingStep(user.uid, 'OnboardingBridge');
@@ -31,15 +45,12 @@ const OnboardingBridgeScreen: React.FC = () => {
       totalSteps={ONBOARDING_SR_TOTAL_STEPS}
       decorativeIcon={Repeat}
       centerContent
-      title="One reset is a start. The change is in the repetition."
+      title={title}
       primaryLabel="Continue"
-      onPrimary={() => navigation.navigate('OnboardingAnchor')}
+      onPrimary={() => navigation.navigate('OnboardingAnchor', { state })}
     >
       <View style={styles.card}>
-        <Text style={styles.cardText}>
-          What you felt was a single reset. The change comes from repetition. Give it two
-          weeks and you'll feel the difference between a one-off and a pattern.
-        </Text>
+        <Text style={styles.cardText}>{cardText}</Text>
       </View>
     </OnboardingScaffold>
   );

--- a/mobile/src/screens/onboarding/OnboardingPeakWindowScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingPeakWindowScreen.tsx
@@ -13,6 +13,7 @@ import {
   type PeakWindow,
   ONBOARDING_SR_TOTAL_STEPS,
   onboardingStepNumber,
+  driverValenceForState,
 } from '../../constants/onboardingStressRecovery';
 import { useAuth } from '../../context/AuthContext';
 import {
@@ -35,6 +36,12 @@ const OnboardingPeakWindowScreen: React.FC = () => {
   const state: BrainState | undefined = route.params?.state;
   const stressorLabels: string[] = route.params?.stressorLabels ?? [];
   const [selected, setSelected] = useState<PeakWindow | null>(null);
+  // "When does it peak?" presumes a problem; positive arrivals get a neutral
+  // framing. Single valence source. Unknown → activated.
+  const peakTitle =
+    driverValenceForState(state) === 'positive'
+      ? 'When would a daily moment fit best?'
+      : 'When does it peak?';
 
   useEffect(() => {
     if (user?.uid) void saveOnboardingStep(user.uid, 'OnboardingPeakWindow');
@@ -55,7 +62,7 @@ const OnboardingPeakWindowScreen: React.FC = () => {
     <OnboardingScaffold
       currentStep={onboardingStepNumber('OnboardingPeakWindow')}
       totalSteps={ONBOARDING_SR_TOTAL_STEPS}
-      title="When does it peak?"
+      title={peakTitle}
       subtitle="This helps us suggest a daily moment. Skip if you're not sure."
       primaryLabel="Continue"
       onPrimary={() => advance(selected)}

--- a/mobile/src/screens/onboarding/OnboardingProtocolScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingProtocolScreen.tsx
@@ -42,6 +42,11 @@ const OnboardingProtocolScreen: React.FC = () => {
       protocolId: protocol?.id ?? DEFAULT_ONBOARDING_PROTOCOL_ID,
       sessionStartedAt: summary?.startedAt ?? Date.now(),
       durationActualSeconds: summary?.durationActualSeconds ?? 0,
+      // Additive completion telemetry — carried to Re-check, which writes the
+      // protocolSession. Defaults cover the no-summary dead-end (missing protocol).
+      completed: summary?.completed ?? false,
+      abandonReason: summary?.abandonReason ?? null,
+      stepsCompleted: summary?.stepsCompleted ?? 0,
     });
   };
 

--- a/mobile/src/screens/onboarding/OnboardingRecheckScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingRecheckScreen.tsx
@@ -23,13 +23,14 @@ import { saveOnboardingStep, saveRecheckShift } from '../../services/firebase/on
 import { writeProtocolSession } from '../../services/firebase/protocolSession.service';
 import {
   computeShift,
+  classifyShiftBucket,
   shiftLine,
   shiftOutcome,
-  BRAIN_LINE,
+  brainLine,
   STATE_LABELS,
   STATE_COLORS,
 } from './onboardingShift';
-import type { BrainState } from '../../types/models';
+import type { BrainState, ProtocolAbandonReason } from '../../types/models';
 
 const OnboardingRecheckScreen: React.FC = () => {
   const navigation = useNavigation<any>();
@@ -40,6 +41,10 @@ const OnboardingRecheckScreen: React.FC = () => {
   const protocolId: string = route.params?.protocolId ?? '';
   const sessionStartedAt: number = route.params?.sessionStartedAt ?? Date.now();
   const durationActualSeconds: number = route.params?.durationActualSeconds ?? 0;
+  // Completion telemetry forwarded from the player summary (additive analytics).
+  const completed: boolean = route.params?.completed ?? false;
+  const abandonReason: ProtocolAbandonReason | null = route.params?.abandonReason ?? null;
+  const stepsCompleted: number = route.params?.stepsCompleted ?? 0;
 
   const [after, setAfter] = useState<BrainState | null>(null);
 
@@ -47,7 +52,10 @@ const OnboardingRecheckScreen: React.FC = () => {
     if (user?.uid) void saveOnboardingStep(user.uid, 'OnboardingRecheck');
   }, [user?.uid]);
 
+  // computeShift still drives the (unchanged) protocolSession.outcome field.
   const shift = useMemo(() => (after ? computeShift(before, after) : null), [before, after]);
+  // The shift LINE + before->after arrow branch on the valence transition.
+  const bucket = useMemo(() => (after ? classifyShiftBucket(before, after) : null), [before, after]);
 
   const onContinue = async () => {
     if (!after || !shift) return;
@@ -63,13 +71,18 @@ const OnboardingRecheckScreen: React.FC = () => {
           userChosenNextStep: null,
           intentPath: 'default',
           sessionStartedAt,
+          // Additive completion telemetry — completed-vs-ended-early becomes
+          // queryable without changing the existing outcome field.
+          completed,
+          abandonReason,
+          stepsCompleted,
         });
         await saveRecheckShift(user.uid, after, shift);
       } catch {
         // Non-blocking — analytics write must never block onboarding.
       }
     }
-    navigation.navigate('OnboardingBridge');
+    navigation.navigate('OnboardingBridge', { state: before });
   };
 
   return (
@@ -91,12 +104,13 @@ const OnboardingRecheckScreen: React.FC = () => {
             isLast={i === BRAIN_STATES.length - 1}
           />
         ))}
-        {after && shift && (
+        {after && bucket && (
           <View style={styles.shiftBlock}>
-            {/* Visual before→after transition. Only on an improved shift: the
-                flat/worse prose intentionally avoids stating a transition
-                (compassion contract), so we don't render a forward arrow there. */}
-            {shift === 'improved' && (
+            {/* Visual before→after transition. Only on a "moved" bucket (an
+                upward shift into a positive state): the other prose
+                intentionally avoids stating a transition (compassion contract),
+                so we don't render a forward arrow there. */}
+            {bucket === 'moved' && (
               <View style={styles.transitionRow}>
                 <View style={styles.statePair}>
                   <View style={[styles.stateDot, { backgroundColor: STATE_COLORS[before] }]} />
@@ -109,8 +123,8 @@ const OnboardingRecheckScreen: React.FC = () => {
                 </View>
               </View>
             )}
-            <Text style={styles.shiftLine}>{shiftLine(before, after, shift)}</Text>
-            <Text style={styles.brainLine}>{BRAIN_LINE}</Text>
+            <Text style={styles.shiftLine}>{shiftLine(before, after, durationActualSeconds)}</Text>
+            <Text style={styles.brainLine}>{brainLine(before)}</Text>
           </View>
         )}
       </View>

--- a/mobile/src/screens/onboarding/OnboardingReflectScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingReflectScreen.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../constants/onboardingStressRecovery';
 import { useAuth } from '../../context/AuthContext';
 import { saveOnboardingStep } from '../../services/firebase/onboardingStressRecovery.service';
-import { onboardingResetLine } from './resolveOnboardingProtocol';
+import { onboardingResetLine, onboardingWhatToExpectLine } from './resolveOnboardingProtocol';
 import { STATE_LABELS, STATE_COLORS } from './onboardingShift';
 import type { BrainState } from '../../types/models';
 
@@ -148,6 +148,13 @@ const OnboardingReflectScreen: React.FC = () => {
   // doesn't get. Falls back to a generic phrase when state is unresolved.
   const resetLine = useMemo(() => onboardingResetLine(resolved.state), [resolved.state]);
 
+  // Calm "what to expect" line under the lead-in. Generic across protocols,
+  // sized to the same duration source; null (state unresolved) drops the line.
+  const whatToExpect = useMemo(
+    () => onboardingWhatToExpectLine(resolved.state),
+    [resolved.state]
+  );
+
   // Primary CTA branches with the lead-in: positive states "Begin", activated
   // (and default) keep "Start the reset". Same valence helper as the lead-in.
   const primaryLabel = useMemo(
@@ -171,6 +178,7 @@ const OnboardingReflectScreen: React.FC = () => {
         peakLabel={peakLabel}
       />
       <Text style={styles.leadIn}>{resetLine}</Text>
+      {whatToExpect && <Text style={styles.whatToExpect}>{whatToExpect}</Text>}
     </OnboardingScaffold>
   );
 };
@@ -226,6 +234,12 @@ const styles = StyleSheet.create({
     fontSize: Typography.fontSize.base,
     color: Colors.softCharcoal,
     lineHeight: Typography.fontSize.base * Typography.lineHeight.normal,
+  },
+  whatToExpect: {
+    marginTop: Spacing.sm,
+    fontSize: Typography.fontSize.sm,
+    color: Colors.mutedSageGray,
+    lineHeight: Typography.fontSize.sm * Typography.lineHeight.normal,
   },
 });
 

--- a/mobile/src/screens/onboarding/__tests__/OnboardingAnchorScreen.test.tsx
+++ b/mobile/src/screens/onboarding/__tests__/OnboardingAnchorScreen.test.tsx
@@ -17,7 +17,10 @@ const mockGetPrefs = jest.fn().mockResolvedValue({});
 const mockUpdatePrefs = jest.fn().mockResolvedValue(undefined);
 const mockGetDoc = jest.fn().mockResolvedValue({ exists: () => false });
 
-jest.mock('@react-navigation/native', () => ({ useNavigation: () => ({ navigate: mockNavigate }) }));
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ params: {} }),
+}));
 jest.mock('../../../context/AuthContext', () => ({ useAuth: () => ({ user: { uid: 'u1' } }) }));
 jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
 jest.mock('firebase/firestore', () => ({

--- a/mobile/src/screens/onboarding/__tests__/OnboardingBackNav.integration.test.tsx
+++ b/mobile/src/screens/onboarding/__tests__/OnboardingBackNav.integration.test.tsx
@@ -75,7 +75,8 @@ const ARRIVAL = 'How are you arriving right now?';
 // positive stem + options (see getDriverQuestion).
 const DRIVERS = "What's behind it?";
 const POSITIVE_DRIVER = "A good night's sleep";
-const PEAK = 'When does it peak?';
+// Steady is positive valence, so the peak screen shows the neutral title.
+const PEAK = 'When would a daily moment fit best?';
 const REFLECT = "Here's where you're starting.";
 
 describe('Onboarding pre-protocol back navigation', () => {

--- a/mobile/src/screens/onboarding/__tests__/onboardingLogic.test.ts
+++ b/mobile/src/screens/onboarding/__tests__/onboardingLogic.test.ts
@@ -1,38 +1,31 @@
 /**
- * Pure-logic coverage for the reflect-back line and the re-check shift —
- * the brand-critical bits: reflect-back mirrors the user's ACTUAL inputs, and
- * a flat/worse shift gets a compassionate (never shaming) response.
+ * Pure-logic coverage for the re-check shift and the Reflect what-to-expect
+ * line — the brand-critical bits: the shift line is valence-coherent (a
+ * positive arrival is never told to "recover"), and an early exit never claims
+ * the protocol's nominal duration.
  */
 import {
-  buildReflectLine,
   computeShift,
+  classifyShiftBucket,
   shiftLine,
   improvedShiftLine,
   shiftOutcome,
+  brainLine,
+  BRAIN_LINE_ACTIVATED,
+  BRAIN_LINE_POSITIVE,
 } from '../onboardingShift';
+import type { ShiftBucket } from '../onboardingShift';
+import { onboardingWhatToExpectLine } from '../resolveOnboardingProtocol';
+import type { BrainState } from '../../../types/models';
 
-describe('buildReflectLine — mirrors actual inputs', () => {
-  test('reflects state + stressor + peak in plain language', () => {
-    const line = buildReflectLine('wired', ['A racing mind'], 'evening');
-    expect(line).toContain('Wired');
-    expect(line).toContain('racing mind');
-    expect(line).toContain('evening');
-  });
+const POSITIVE_HOLD =
+  "You're in a good place. Showing up when you already feel good matters just as much as when things are hard.";
+const POSITIVE_DIP =
+  "States move through the day, and noticing the shift is its own kind of skill. You're in a tougher spot than when you started, and that's exactly what these check-ins help you catch.";
+const ACTIVATED_RIL =
+  "Recovery isn't linear. Some days the shift is quiet. Showing up is the part that compounds.";
 
-  test('omits clauses for skipped stressor/peak but still names the state', () => {
-    const line = buildReflectLine('foggy', [], null);
-    expect(line).toContain('Foggy');
-    expect(line).not.toContain('with ');
-    expect(line).not.toContain('in the ');
-  });
-
-  test('fully-skipped (no state) falls back to the generic downshift line', () => {
-    const line = buildReflectLine(null, [], null);
-    expect(line).toBe("Here's a five-minute reset to help your system downshift.");
-  });
-});
-
-describe('computeShift', () => {
+describe('computeShift (drives the unchanged protocolSession.outcome)', () => {
   test('toward regulation → improved', () => {
     expect(computeShift('wired', 'steady')).toBe('improved');
   });
@@ -44,55 +37,99 @@ describe('computeShift', () => {
   });
 });
 
-describe('shiftLine — compassionate, never shaming', () => {
-  // Duration is sized to the protocol the user actually completed (resolved
-  // via resolveOnboardingProtocol), matching the pre-protocol Reflect copy.
-  test('improved (Wired → Cyclic Sighing, 2 min) says "in two minutes"', () => {
-    expect(shiftLine('wired', 'steady', 'improved')).toBe(
-      'You moved from Wired to Steady in two minutes.'
-    );
-  });
-  test('improved (Foggy → 5-min protocol) says "in five minutes"', () => {
-    expect(shiftLine('foggy', 'clear', 'improved')).toBe(
-      'You moved from Foggy to Clear in five minutes.'
-    );
-  });
-  test('flat does not imply the user did it wrong', () => {
-    const line = shiftLine('steady', 'steady', 'flat');
-    expect(line.toLowerCase()).toContain("isn't linear");
-    expect(line.toLowerCase()).not.toMatch(/wrong|fail|should have|try harder/);
-  });
-  test('worse is reassuring, not a penalty', () => {
-    const line = shiftLine('clear', 'wired', 'worse');
-    expect(line.toLowerCase()).not.toMatch(/wrong|fail|penalty|missed/);
+describe('classifyShiftBucket — full 25-cell valence map', () => {
+  // before → after → expected bucket. activated = wired/foggy; positive =
+  // steady/clear/alive. "moved" = upward into a positive state (only bucket
+  // with the before→after arrow).
+  const MAP: Record<BrainState, Record<BrainState, ShiftBucket>> = {
+    wired: { wired: 'activated', foggy: 'activated', steady: 'moved', clear: 'moved', alive: 'moved' },
+    foggy: { wired: 'activated', foggy: 'activated', steady: 'moved', clear: 'moved', alive: 'moved' },
+    steady: { wired: 'positive_dip', foggy: 'positive_dip', steady: 'positive_hold', clear: 'moved', alive: 'moved' },
+    clear: { wired: 'positive_dip', foggy: 'positive_dip', steady: 'positive_hold', clear: 'positive_hold', alive: 'moved' },
+    alive: { wired: 'positive_dip', foggy: 'positive_dip', steady: 'positive_hold', clear: 'positive_hold', alive: 'positive_hold' },
+  };
+
+  (Object.keys(MAP) as BrainState[]).forEach((before) => {
+    (Object.keys(MAP[before]) as BrainState[]).forEach((after) => {
+      test(`${before} → ${after} = ${MAP[before][after]}`, () => {
+        expect(classifyShiftBucket(before, after)).toBe(MAP[before][after]);
+      });
+    });
   });
 });
 
-describe('improvedShiftLine — duration phrasing + graceful fallback', () => {
+describe('shiftLine — valence-coherent, never shaming', () => {
+  test('moved (Wired → Steady, 2 min actual) names the duration', () => {
+    expect(shiftLine('wired', 'steady', 120)).toBe('You moved from Wired to Steady in two minutes.');
+  });
+  test('moved (upward positive→positive, Steady → Clear, 5 min) names the duration', () => {
+    expect(shiftLine('steady', 'clear', 300)).toBe('You moved from Steady to Clear in five minutes.');
+  });
+  test('moved with a short early exit drops the claim ("just now")', () => {
+    expect(shiftLine('wired', 'clear', 40)).toBe('You moved from Wired to Clear just now.');
+  });
+  test('activated→activated stays the compassionate line', () => {
+    expect(shiftLine('wired', 'wired', 0)).toBe(ACTIVATED_RIL);
+    expect(shiftLine('wired', 'foggy', 0)).toBe(ACTIVATED_RIL);
+  });
+  test('positive hold (Alive → Alive) affirms instead of consoling', () => {
+    expect(shiftLine('alive', 'alive', 0)).toBe(POSITIVE_HOLD);
+    expect(shiftLine('clear', 'steady', 0)).toBe(POSITIVE_HOLD); // dip within good
+  });
+  test('positive dip (Clear → Wired) names the catch, not a failure', () => {
+    expect(shiftLine('clear', 'wired', 0)).toBe(POSITIVE_DIP);
+    expect(shiftLine('clear', 'wired', 0).toLowerCase()).not.toMatch(/wrong|fail|penalty/);
+  });
+});
+
+describe('improvedShiftLine — actual-duration phrasing + graceful fallback', () => {
   test('120s renders "in two minutes"', () => {
-    expect(improvedShiftLine('wired', 'steady', 120)).toBe(
-      'You moved from Wired to Steady in two minutes.'
-    );
+    expect(improvedShiftLine('wired', 'steady', 120)).toBe('You moved from Wired to Steady in two minutes.');
   });
   test('300s renders "in five minutes"', () => {
-    expect(improvedShiftLine('foggy', 'clear', 300)).toBe(
-      'You moved from Foggy to Clear in five minutes.'
-    );
+    expect(improvedShiftLine('foggy', 'clear', 300)).toBe('You moved from Foggy to Clear in five minutes.');
   });
   test('unresolved duration (null) drops the claim with "just now"', () => {
-    expect(improvedShiftLine('wired', 'steady', null)).toBe(
-      'You moved from Wired to Steady just now.'
-    );
+    expect(improvedShiftLine('wired', 'steady', null)).toBe('You moved from Wired to Steady just now.');
   });
-  test('zero duration falls back to "just now" rather than "zero minutes"', () => {
-    expect(improvedShiftLine('wired', 'steady', 0)).toBe(
-      'You moved from Wired to Steady just now.'
-    );
+  test('zero duration falls back to "just now"', () => {
+    expect(improvedShiftLine('wired', 'steady', 0)).toBe('You moved from Wired to Steady just now.');
+  });
+  test('sub-two-minute duration falls back to "just now" (no "one minutes")', () => {
+    expect(improvedShiftLine('wired', 'steady', 80)).toBe('You moved from Wired to Steady just now.');
   });
 });
 
-describe('shiftOutcome — maps shift to a ProtocolSessionOutcome', () => {
+describe('brainLine — branches on initial-state valence', () => {
+  test('activated initial → stress-recovery framing', () => {
+    expect(brainLine('wired')).toBe(BRAIN_LINE_ACTIVATED);
+    expect(brainLine('foggy')).toBe(BRAIN_LINE_ACTIVATED);
+  });
+  test('positive initial → resilience framing', () => {
+    expect(brainLine('steady')).toBe(BRAIN_LINE_POSITIVE);
+    expect(brainLine('clear')).toBe(BRAIN_LINE_POSITIVE);
+    expect(brainLine('alive')).toBe(BRAIN_LINE_POSITIVE);
+  });
+});
+
+describe('shiftOutcome — maps shift to a ProtocolSessionOutcome (unchanged)', () => {
   test('improved → shifted', () => expect(shiftOutcome('improved')).toBe('shifted'));
   test('flat → maintenance', () => expect(shiftOutcome('flat')).toBe('maintenance'));
   test('worse → not_shifted', () => expect(shiftOutcome('worse')).toBe('not_shifted'));
+});
+
+describe('onboardingWhatToExpectLine — generic, duration-sized, null-safe', () => {
+  test('Wired (2-min Cyclic Sighing) names "about two minutes"', () => {
+    expect(onboardingWhatToExpectLine('wired')).toBe(
+      "It's about two minutes, fully guided, so there's nothing to figure out. Just follow along."
+    );
+  });
+  test('Steady (5-min protocol) names "about five minutes"', () => {
+    expect(onboardingWhatToExpectLine('steady')).toBe(
+      "It's about five minutes, fully guided, so there's nothing to figure out. Just follow along."
+    );
+  });
+  test('unresolved state → null (screen omits the line)', () => {
+    expect(onboardingWhatToExpectLine(null)).toBeNull();
+  });
 });

--- a/mobile/src/screens/onboarding/onboardingShift.ts
+++ b/mobile/src/screens/onboarding/onboardingShift.ts
@@ -1,12 +1,17 @@
 /**
- * Pure copy/logic for the reflect-back (screen 5) and re-check shift (screen 7).
- * No React/RN imports, so it's unit-testable without loading the screen's
- * dependency tree. Screens import these helpers.
+ * Pure copy/logic for the re-check shift (screen 7). No React/RN imports, so
+ * it's unit-testable without loading the screen's dependency tree. Screens
+ * import these helpers.
+ *
+ * Valence coherence: the shift LINE branches on the before->after valence
+ * transition (classifyShiftBucket); BRAIN_LINE branches on the INITIAL state's
+ * valence via driverValenceForState (the single valence source shared with the
+ * Reflect lead-in and the driver screen). No new valence maps.
  */
 import type { BrainState, ProtocolSessionOutcome } from '../../types/models';
 import { BRAIN_STATES } from '../../components/dashboard/brainStateCheckin/brainStateOptions';
-import { PEAK_WINDOW_OPTIONS, type PeakWindow } from '../../constants/onboardingStressRecovery';
-import { resolveOnboardingProtocol, minutesWord } from './resolveOnboardingProtocol';
+import { driverValenceForState } from '../../constants/onboardingStressRecovery';
+import { minutesWord } from './resolveOnboardingProtocol';
 
 export const STATE_LABELS: Record<BrainState, string> = BRAIN_STATES.reduce(
   (acc, o) => ({ ...acc, [o.state]: o.label }),
@@ -20,31 +25,29 @@ export const STATE_COLORS: Record<BrainState, string> = BRAIN_STATES.reduce(
   {} as Record<BrainState, string>
 );
 
-export const PEAK_LABELS: Record<PeakWindow, string> = PEAK_WINDOW_OPTIONS.reduce(
-  (acc, o) => ({ ...acc, [o.id]: o.label }),
-  {} as Record<PeakWindow, string>
-);
-
-export const GENERIC_REFLECT_LINE = "Here's a five-minute reset to help your system downshift.";
-
-export const BRAIN_LINE =
+/**
+ * The "your brain is learning" reassurance under the shift line (screen 7),
+ * branched on the INITIAL state's valence. Activated arrivals get the
+ * stress-recovery framing; positive arrivals get a resilience framing that
+ * doesn't presume they needed to recover.
+ */
+export const BRAIN_LINE_ACTIVATED =
   'Small recovery moments like this, repeated, are how your brain learns to handle stress better over time.';
 
-/** Screen 5 — mirror the user's ACTUAL inputs (never a static string). */
-export function buildReflectLine(
-  state: BrainState | null,
-  stressorLabels: string[],
-  peak: PeakWindow | null
-): string {
-  if (!state) return GENERIC_REFLECT_LINE;
-  const stressorClause = stressorLabels.length ? `, with ${stressorLabels[0].toLowerCase()}` : '';
-  const peakClause = peak ? ` in the ${PEAK_LABELS[peak].toLowerCase()}` : '';
-  return `You're arriving ${STATE_LABELS[state]}${stressorClause}${peakClause}. ${GENERIC_REFLECT_LINE}`;
+export const BRAIN_LINE_POSITIVE =
+  'Small moments like this, repeated, are how your brain builds resilience over time.';
+
+export function brainLine(initialState: BrainState): string {
+  return driverValenceForState(initialState) === 'positive'
+    ? BRAIN_LINE_POSITIVE
+    : BRAIN_LINE_ACTIVATED;
 }
 
 export type Shift = 'improved' | 'flat' | 'worse';
 
-// Ordinal toward regulation; used only to phrase the shift, never to gate.
+// Ordinal toward regulation. Drives the legacy improved/flat/worse outcome
+// (shiftOutcome → protocolSession.outcome, unchanged) and the within-valence
+// direction check in classifyShiftBucket. Never used to gate.
 const RANK: Record<BrainState, number> = { wired: 0, foggy: 1, steady: 2, clear: 3, alive: 4 };
 
 export function computeShift(before: BrainState, after: BrainState): Shift {
@@ -60,12 +63,34 @@ export function shiftOutcome(shift: Shift): ProtocolSessionOutcome {
 }
 
 /**
- * Improved-shift line, sized to the protocol the user actually completed.
- * `durationSeconds` of null/0 (state lost, protocol unresolved, Firestore
- * unreachable) drops the duration claim entirely — "just now" — rather than
- * risking a wrong duration like the hardcoded "five minutes" did for the Wired
- * two-minute Cyclic Sighing path. Pure formatter; resolution lives in
- * `shiftLine`/`resolveOnboardingProtocol`.
+ * Valence-transition bucket for the re-check shift line. Single valence source
+ * (driverValenceForState); positive = steady/clear/alive, activated = wired/foggy.
+ *
+ *   moved         — re-checked UP into a positive state (the only bucket that
+ *                   earns the "you moved" line + the before->after arrow row).
+ *                   Covers activated->positive and upward positive->positive.
+ *   activated     — both states activated (flat, or a lateral wired<->foggy move).
+ *   positive_hold — both states positive but not an upward move (flat or a dip
+ *                   that stays inside the good range).
+ *   positive_dip  — started positive, re-checked into an activated state.
+ */
+export type ShiftBucket = 'moved' | 'activated' | 'positive_hold' | 'positive_dip';
+
+export function classifyShiftBucket(before: BrainState, after: BrainState): ShiftBucket {
+  const beforePositive = driverValenceForState(before) === 'positive';
+  const afterPositive = driverValenceForState(after) === 'positive';
+  if (afterPositive && RANK[after] > RANK[before]) return 'moved';
+  if (!beforePositive && !afterPositive) return 'activated';
+  if (beforePositive && afterPositive) return 'positive_hold';
+  return 'positive_dip';
+}
+
+/**
+ * "You moved …" line, sized to the ACTUAL elapsed time so an early exit can't
+ * falsely claim the protocol's nominal length. Durations that round to under
+ * two minutes (and null/0) drop the duration claim entirely — "just now" —
+ * because we only ship plural-minute copy ("two/five minutes"); this also
+ * avoids an ungrammatical "one minutes" / "zero minutes". Pure formatter.
  */
 export function improvedShiftLine(
   before: BrainState,
@@ -73,21 +98,32 @@ export function improvedShiftLine(
   durationSeconds: number | null
 ): string {
   const movement = `You moved from ${STATE_LABELS[before]} to ${STATE_LABELS[after]}`;
-  if (!durationSeconds || durationSeconds <= 0) {
+  const minutes = durationSeconds ? Math.round(durationSeconds / 60) : 0;
+  if (!durationSeconds || durationSeconds <= 0 || minutes < 2) {
     return `${movement} just now.`;
   }
   return `${movement} in ${minutesWord(durationSeconds)} minutes.`;
 }
 
-/** Screen 7 — surface before→after; flat/worse gets a compassionate reframe. */
-export function shiftLine(before: BrainState, after: BrainState, shift: Shift): string {
-  if (shift === 'improved') {
-    // Resolve from the pre-protocol state (`before`) via the SAME helper the
-    // Reflect screen uses, so pre-protocol and post-protocol cards agree on the
-    // duration. Wired -> Cyclic Sighing (120s -> "two"); the other states map to
-    // 5-minute protocols ("five").
-    const protocol = resolveOnboardingProtocol(before);
-    return improvedShiftLine(before, after, protocol?.durationSeconds ?? null);
+/**
+ * Screen 7 — the before->after shift line, branched by valence transition.
+ * `durationActualSeconds` is the real elapsed time forwarded from the player
+ * (null/short → "just now"). Outcome derivation (computeShift/shiftOutcome) is
+ * separate and unchanged.
+ */
+export function shiftLine(
+  before: BrainState,
+  after: BrainState,
+  durationActualSeconds: number | null
+): string {
+  switch (classifyShiftBucket(before, after)) {
+    case 'moved':
+      return improvedShiftLine(before, after, durationActualSeconds);
+    case 'activated':
+      return "Recovery isn't linear. Some days the shift is quiet. Showing up is the part that compounds.";
+    case 'positive_hold':
+      return "You're in a good place. Showing up when you already feel good matters just as much as when things are hard.";
+    case 'positive_dip':
+      return "States move through the day, and noticing the shift is its own kind of skill. You're in a tougher spot than when you started, and that's exactly what these check-ins help you catch.";
   }
-  return "Recovery isn't linear. Some days the shift is quiet. Showing up is the part that compounds.";
 }

--- a/mobile/src/screens/onboarding/resolveOnboardingProtocol.ts
+++ b/mobile/src/screens/onboarding/resolveOnboardingProtocol.ts
@@ -78,3 +78,16 @@ export function onboardingResetLine(state: BrainState | null): string {
     ? `Here's a ${minutesWord(seconds)}-minute practice to help you stay with this.`
     : `Here's a ${minutesWord(seconds)}-minute reset to help your system downshift.`;
 }
+
+/**
+ * The calm "what to expect" line under the Reflect lead-in. Generic across
+ * protocols (no valence branch) and sized to the SAME duration source the
+ * lead-in uses. Returns null when the duration can't be resolved (state lost),
+ * so the screen simply omits the line rather than render a broken "{n}".
+ */
+export function onboardingWhatToExpectLine(state: BrainState | null): string | null {
+  const protocol = state ? resolveOnboardingProtocol(state) : null;
+  const seconds = protocol?.durationSeconds;
+  if (!seconds || seconds <= 0) return null;
+  return `It's about ${minutesWord(seconds)} minutes, fully guided, so there's nothing to figure out. Just follow along.`;
+}

--- a/mobile/src/services/firebase/protocolSession.service.ts
+++ b/mobile/src/services/firebase/protocolSession.service.ts
@@ -25,6 +25,7 @@ import { logger } from '../../utils/logger';
 import type { BrainState, IntentPath } from '../../types/models';
 import type {
   MovementModality,
+  ProtocolAbandonReason,
   ProtocolNextStep,
   ProtocolSessionOutcome,
   ProtocolTimeWindow,
@@ -58,6 +59,14 @@ export interface ProtocolSessionWritePayload {
   // predate this feature and lack the field. Patterns queries should
   // null-check before grouping by modality.
   selectedModality?: MovementModality | null;
+  // Optional completion telemetry forwarded from the GuidedSessionPlayer
+  // summary (currently the onboarding protocol step). Additive: lets a query
+  // distinguish a fully-played session from an early exit / audio failure
+  // without changing the existing `outcome` field. Callers that don't supply
+  // these omit them, so the doc shape is unchanged for non-onboarding writes.
+  completed?: boolean;
+  abandonReason?: ProtocolAbandonReason | null;
+  stepsCompleted?: number;
 }
 
 export interface WriteProtocolSessionOptions {
@@ -128,6 +137,12 @@ export async function writeProtocolSession(
         ...(payload.selectedModality != null
           ? { selectedModality: payload.selectedModality }
           : {}),
+        // Additive completion telemetry. Written only when the caller supplies
+        // them (`!== undefined`), so `false`/`null` are still recorded for
+        // onboarding while other callers leave the doc shape unchanged.
+        ...(payload.completed !== undefined ? { completed: payload.completed } : {}),
+        ...(payload.abandonReason !== undefined ? { abandonReason: payload.abandonReason } : {}),
+        ...(payload.stepsCompleted !== undefined ? { stepsCompleted: payload.stepsCompleted } : {}),
         // Server-side timestamps so multi-device clocks don't skew
         // ordering. sessionStartedAt is the device-local moment the
         // session began; createdAt is when the doc landed in Firestore.


### PR DESCRIPTION
Makes every retrospective/affirming onboarding surface coherent for positive arrivals (Steady/Clear/Alive), which previously defaulted to stress/recovery framing. Single valence source throughout: the existing `driverValenceForState` (activated = wired/foggy; positive = steady/clear/alive). No new valence map. Copy is verbatim per spec; no em/en dashes.

## What changed
- **Re-check shift line** now branches on a valence-transition classifier (`classifyShiftBucket`) instead of rank-only improved/flat/worse:
  - `moved` (upward into a positive state) -> "You moved from X to Y in N minutes" + before/after arrow
  - `activated` (both activated) -> "Recovery isn't linear..."
  - `positive_hold` (both positive, flat/dip) -> "You're in a good place. Showing up when you already feel good matters just as much as when things are hard."
  - `positive_dip` (positive -> activated) -> "States move through the day, and noticing the shift is its own kind of skill..."
  - Full 25-cell map is encoded as a test.
- **Duration honesty:** the "you moved" line is now sized from ACTUAL elapsed time, not the protocol's nominal length. Anything that rounds under two minutes (and null) falls back to "just now" (we only ship plural-minute copy; no singular template, by decision).
- **BRAIN_LINE** branches on initial-state valence (activated keeps the stress line; positive gets a resilience line). The positive shift line was reworded to avoid duplicating "resilience...over time" with BRAIN_LINE.
- **"reset"-word + peak leaks**, branched on initial-state valence: Bridge ("practice"/"moment"), Anchor ("check in"), Peak Window ("When would a daily moment fit best?").
- **Reflect** gains one calm, generic what-to-expect line under the lead-in ("It's about N minutes, fully guided...").
- **Additive analytics:** `completed` / `abandonReason` / `stepsCompleted` are forwarded from the player summary and written to `protocolSessions` (only when supplied). The existing `outcome` field and its derivation are unchanged; non-onboarding callers' doc shape is identical. Completed-vs-ended-early is now queryable.
- Removed dead `GENERIC_REFLECT_LINE` / `buildReflectLine` / `PEAK_LABELS`.

## Commits (five logical chunks)
1. shift-line classifier + actual-duration + dead-code removal
2. additive completion telemetry (service payload + player forwarding)
3. valence-branched copy across re-check / bridge / anchor / peak + state threading
4. Reflect what-to-expect line
5. tests

## Verification
- Onboarding + protocolSession suites: 83/83 pass (run from `mobile/`).
- `tsc --noEmit` error count = 180 (frozen baseline unchanged).
- eslint on changed files: 0 errors.

## Not in this PR (flagged for a standalone fix)
`firestore.rules:193` has a stray `\` instead of `//` in a comment - should be fixed before any future `firebase deploy --only firestore:rules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)