### PR TITLE
B-3b: browse completion uses the felt reflection (Issues 1+2)

### DIFF
--- a/mobile/src/__tests__/brandCopyGuard.test.ts
+++ b/mobile/src/__tests__/brandCopyGuard.test.ts
@@ -32,6 +32,11 @@ const COPY_SOURCES = [
   'src/components/dashboard/dashboardInsights.ts',
   'src/engine/planMap.ts',
   'src/components/checkin/flow/PointerOfferStepView.tsx',
+  // Four-Pillar IA Energy pillar screens (B-3b). User-facing hub + browse
+  // list copy; guarded here so the pillar rollout can't reintroduce an
+  // em dash / optim* in the rendered strings.
+  'src/screens/Energy/EnergyHubScreen.tsx',
+  'src/screens/Energy/EnergyBrowseListScreen.tsx',
 ];
 
 // U+2014 EM DASH, built via char code so no literal em-dash byte lives in

--- a/mobile/src/components/checkin/flow/BrowseRunFlow.tsx
+++ b/mobile/src/components/checkin/flow/BrowseRunFlow.tsx
@@ -3,11 +3,14 @@
 // State machine: running → re_check → flow_complete | abandoned.
 //
 // Used by PracticeRunScreen when the user launches a protocol from
-// the Practices index without going through the standard check-in
-// flow. The user has already self-selected the protocol; this flow
-// plays it and captures stateAfter at re-check so we still get a
-// state-transition data point (re-check IS the measurement, per
-// Build Guide §1).
+// the Practices index / Energy hub without going through the standard
+// check-in flow. The user has already self-selected the protocol; this
+// flow plays it and captures a post-protocol attestation at the re_check
+// step. B-3b Issue 2: the re_check step renders by context — the check-in
+// continuation (ctx present) keeps the deprecated 5-state re-check feeding
+// the response screen; true browse (ctx absent) shows the modern felt
+// reflection (ReflectionStepView) and persists the reflectionId WITHOUT
+// synthesizing a 5-state stateAfter.
 //
 // Differences from CheckInFlow:
 //   - No state_pick / time_pick / recommendation steps.
@@ -45,7 +48,9 @@ import {
 import { GuidedSessionPlayer } from '../../protocol/GuidedSessionPlayer';
 import { LightMovementProtocolFlow } from '../../protocol/LightMovementProtocolFlow';
 import { ReCheckStepView } from './ReCheckStepView';
+import { ReflectionStepView } from './ReflectionStepView';
 import { ResponseStepView } from './ResponseStepView';
+import { slotDirectionForPractice } from './reducer';
 import {
   browseRunReducer,
   initBrowseRunFlow,
@@ -168,8 +173,15 @@ export function BrowseRunFlow({
           // BrowseRunFlow session that abandoned, and the original
           // CheckInFlow context's state is the most recent
           // attestation we have for the user).
+          // B-3b Issue 2 widened stateAfter to BrainState | null for the
+          // true-browse reflection path. This block only runs with ctx
+          // present (a check-in continuation), where a flow_complete always
+          // carries a concrete re-check stateAfter; `?? ctx.state` is a
+          // type-safe guard for the unreachable null case.
           const stateForLegacyDoc =
-            state.step === 'flow_complete' ? state.stateAfter : ctx.state;
+            state.step === 'flow_complete'
+              ? state.stateAfter ?? ctx.state
+              : ctx.state;
           writes.push(
             (async () => {
               await writeBrainStateCheckInDoc(
@@ -283,11 +295,31 @@ function renderStep(
       );
     }
     case 're_check':
+      // Check-in continuation (ctx present) keeps the deprecated 5-state
+      // re-check, which feeds the response screen + transition classifier —
+      // this is the check-in-launched path and must NOT change (B-3b Issue 2
+      // is scoped to true browse).
+      if (state.checkInFlowContext) {
+        return (
+          <ReCheckStepView
+            protocol={state.protocol}
+            onSelect={(stateAfter) =>
+              dispatch({ type: 'state_after_selected', stateAfter })
+            }
+          />
+        );
+      }
+      // True browse (ctx absent) — B-3b Issue 2: the modern felt reflection
+      // (same component + props the check-in loop uses), derived from the
+      // protocol already in scope. This retires the last user-facing 5-state
+      // browse surface; the chosen reflectionId is persisted, no stateAfter.
       return (
-        <ReCheckStepView
+        <ReflectionStepView
           protocol={state.protocol}
-          onSelect={(stateAfter) =>
-            dispatch({ type: 'state_after_selected', stateAfter })
+          pillar={state.protocol.pillar}
+          direction={slotDirectionForPractice(state.protocol)}
+          onSelect={(reflectionId) =>
+            dispatch({ type: 'reflection_selected', reflectionId })
           }
         />
       );

--- a/mobile/src/components/checkin/flow/BrowseRunFlow.tsx
+++ b/mobile/src/components/checkin/flow/BrowseRunFlow.tsx
@@ -264,6 +264,9 @@ function renderStep(
             onExit={handlePlayerExit}
             onModalitySelected={onModalitySelected}
             onCancel={onCancel ?? (() => {})}
+            // Preroll (idle) exit routes back without an abandoned-session
+            // write — same destination as the picker cancel.
+            onExitBeforeStart={onCancel}
           />
         );
       }
@@ -272,6 +275,10 @@ function renderStep(
           protocol={state.protocol}
           stateBefore={stateBefore}
           onExit={handlePlayerExit}
+          // Browse preroll exit: route back to the browse list (no
+          // abandoned-session write — nothing started yet). Check-in does not
+          // pass this, so its preroll behavior is unchanged.
+          onExitBeforeStart={onCancel}
         />
       );
     }

--- a/mobile/src/components/checkin/flow/__tests__/BrowseRunFlow.test.tsx
+++ b/mobile/src/components/checkin/flow/__tests__/BrowseRunFlow.test.tsx
@@ -446,10 +446,10 @@ describe('BrowseRunFlow — terminal write with CheckInFlowContext (Bug A v2 fix
   });
 });
 
-describe('BrowseRunFlow — terminal write WITHOUT context (true-browse legacy behavior)', () => {
-  it('does NOT invoke writeBrainStateCheckInDoc or maybeMarkFirstShift when context is absent', async () => {
+describe('BrowseRunFlow — terminal write WITHOUT context (true-browse: felt reflection)', () => {
+  it('shows the felt reflection (not the 5-state re-check) and writes browse_launched + reflectionId, stateAfter null', async () => {
     const onComplete = jest.fn();
-    const { findByTestId, getByLabelText } = render(
+    const { findByTestId, queryByTestId } = render(
       <BrowseRunFlow
         protocol={NSDR_20}
         {...TEST_PROPS}
@@ -460,19 +460,26 @@ describe('BrowseRunFlow — terminal write WITHOUT context (true-browse legacy b
     act(() => {
       lastOnExit!(summary({ completed: true, protocolId: 'nsdr-20' }));
     });
-    expect(await findByTestId('checkin-flow-re-check')).toBeTruthy();
-    fireEvent.press(getByLabelText('Clear'));
+    // B-3b Issue 2: the modern reflection renders, NOT the deprecated
+    // 5-state re-check (Wired/Foggy/Steady/Clear/Alive).
+    expect(await findByTestId('checkin-flow-reflection')).toBeTruthy();
+    expect(queryByTestId('checkin-flow-re-check')).toBeNull();
+    // NSDR-20 is energy/settle → the strong-positive chip id is 'calmer'.
+    fireEvent.press(await findByTestId('checkin-flow-reflection-chip-calmer'));
 
     await waitFor(
       () => expect(onComplete).toHaveBeenCalledTimes(1),
       { timeout: TERMINAL_ON_COMPLETE_TIMEOUT_MS }
     );
 
-    // Authoritative write still fires.
+    // Authoritative write still fires — existing browse_launched shape plus
+    // reflectionId, with stateAfter NULL (no synthesized 5-state).
     expect(writeProtocolSessionMock).toHaveBeenCalledTimes(1);
     const [, payload] = (writeProtocolSessionMock as jest.Mock).mock.calls[0];
     expect(payload.outcome).toBe('browse_launched');
     expect(payload.stateBefore).toBeNull();
+    expect(payload.stateAfter).toBeNull();
+    expect(payload.reflectionId).toBe('calmer');
 
     // Legacy helpers NOT called (preserves isolated browse semantics).
     // Round 14 — both writeBrainStateCheckInDoc and maybeMarkFirstShift
@@ -569,8 +576,8 @@ describe('BrowseRunFlow — response step (round 12 Finding H fix)', () => {
     expect(payload.outcome).toBe('not_shifted');
   });
 
-  it('ctx absent: state_after_selected goes straight to flow_complete (no response step rendered)', async () => {
-    const { findByTestId, queryByTestId, getByLabelText } = render(
+  it('ctx absent: reflection goes straight to flow_complete (no response step rendered)', async () => {
+    const { findByTestId, queryByTestId } = render(
       <BrowseRunFlow
         protocol={NSDR_20}
         {...TEST_PROPS}
@@ -581,8 +588,8 @@ describe('BrowseRunFlow — response step (round 12 Finding H fix)', () => {
     act(() => {
       lastOnExit!(summary({ completed: true, protocolId: 'nsdr-20' }));
     });
-    expect(await findByTestId('checkin-flow-re-check')).toBeTruthy();
-    fireEvent.press(getByLabelText('Clear'));
+    expect(await findByTestId('checkin-flow-reflection')).toBeTruthy();
+    fireEvent.press(await findByTestId('checkin-flow-reflection-chip-calmer'));
 
     await waitFor(
       () => expect(writeProtocolSessionMock).toHaveBeenCalled(),

--- a/mobile/src/components/checkin/flow/__tests__/browseRunReducer.test.ts
+++ b/mobile/src/components/checkin/flow/__tests__/browseRunReducer.test.ts
@@ -106,21 +106,34 @@ describe('browseRunReducer — running → re_check (completed) or abandoned (en
 });
 
 describe('browseRunReducer — re_check transition (Finding H fix branches)', () => {
-  // Round 12 (Finding H): re_check → response when ctx present;
-  // re_check → flow_complete (short-circuit) when ctx absent.
+  // Round 12 (Finding H): re_check → response when ctx present.
+  // B-3b Issue 2: true browse (ctx absent) now captures a felt
+  // reflection (reflection_selected → flow_complete), NOT a 5-state.
 
-  it('ctx absent: state_after_selected short-circuits to flow_complete (true-browse)', () => {
+  it('ctx absent: reflection_selected goes to flow_complete with reflectionId and stateAfter null (no synthesized 5-state)', () => {
     const result = browseRunReducer(reCheckState(), {
-      type: 'state_after_selected',
-      stateAfter: 'clear',
+      type: 'reflection_selected',
+      reflectionId: 'calmer',
     });
     expect(result.step).toBe('flow_complete');
     if (result.step === 'flow_complete') {
-      expect(result.stateAfter).toBe('clear');
+      // No 5-state synthesized from the reflection chip.
+      expect(result.stateAfter).toBeNull();
+      expect(result.reflectionId).toBe('calmer');
       expect(result.protocol).toBe(NSDR_20);
       expect(result.durationActualSeconds).toBe(1200);
       expect(result.userChosenNextStep).toBeNull();
+      expect(result.checkInFlowContext).toBeNull();
     }
+  });
+
+  it('ctx absent: state_after_selected is now a no-op (true browse uses reflection, not the 5-state)', () => {
+    const start = reCheckState();
+    const result = browseRunReducer(start, {
+      type: 'state_after_selected',
+      stateAfter: 'clear',
+    });
+    expect(result).toBe(start);
   });
 
   it('ctx present: state_after_selected transitions to response (round 12 Finding H)', () => {
@@ -266,7 +279,8 @@ describe('browseRunReducer — terminal absorbing-state behavior', () => {
     sessionStartedAt: 1_000_000,
     sessionEndedAt: 1_000_000 + 1_200_000,
     durationActualSeconds: 1200,
-    stateAfter: 'clear',
+    stateAfter: null,
+    reflectionId: 'calmer',
     checkInFlowContext: null,
     userChosenNextStep: null,
   };
@@ -274,8 +288,8 @@ describe('browseRunReducer — terminal absorbing-state behavior', () => {
   it('any action on abandoned returns the same state', () => {
     expect(
       browseRunReducer(abandoned, {
-        type: 'state_after_selected',
-        stateAfter: 'clear',
+        type: 'reflection_selected',
+        reflectionId: 'calmer',
       })
     ).toBe(abandoned);
     expect(
@@ -290,15 +304,15 @@ describe('browseRunReducer — terminal absorbing-state behavior', () => {
   it('any action on flow_complete returns the same state', () => {
     expect(
       browseRunReducer(flowComplete, {
-        type: 'state_after_selected',
-        stateAfter: 'wired',
+        type: 'reflection_selected',
+        reflectionId: 'still_wound_up',
       })
     ).toBe(flowComplete);
   });
 });
 
 describe('browseRunReducer — full happy path', () => {
-  it('init → player completed → state_after_selected → flow_complete', () => {
+  it('init → player completed → reflection_selected → flow_complete (true browse)', () => {
     let state: BrowseRunFlowState = initBrowseRunFlow({
       protocol: NSDR_20,
       nowMs: 1_000_000,
@@ -313,12 +327,13 @@ describe('browseRunReducer — full happy path', () => {
     expect(state.step).toBe('re_check');
 
     state = browseRunReducer(state, {
-      type: 'state_after_selected',
-      stateAfter: 'clear',
+      type: 'reflection_selected',
+      reflectionId: 'calmer',
     });
     expect(state.step).toBe('flow_complete');
     if (state.step === 'flow_complete') {
-      expect(state.stateAfter).toBe('clear');
+      expect(state.reflectionId).toBe('calmer');
+      expect(state.stateAfter).toBeNull();
       expect(state.protocol).toBe(NSDR_20);
     }
   });
@@ -377,28 +392,32 @@ describe('browseRunReducer — full happy path', () => {
 });
 
 describe('mapBrowseTerminalToPayload — Case 4 schema mapping (no context)', () => {
-  it('flow_complete → outcome="browse_launched", stateBefore=null, stateAfter=captured', () => {
+  it('flow_complete (reflection) → browse_launched shape + reflectionId, stateBefore/stateAfter null', () => {
     const terminal: BrowseFlowCompleteStep = {
       step: 'flow_complete',
       protocol: NSDR_20,
       sessionStartedAt: 1_000_000,
       sessionEndedAt: 1_000_000 + 1_200_000,
       durationActualSeconds: 1200,
-      stateAfter: 'clear',
+      stateAfter: null,
+      reflectionId: 'calmer',
       checkInFlowContext: null,
       userChosenNextStep: null,
     };
     const payload = mapBrowseTerminalToPayload(terminal, 'default');
+    // The existing browse_launched row shape PLUS the reflectionId field —
+    // NOT a new third shape, and stateAfter stays null (no synthesized state).
     expect(payload).toEqual({
       protocolId: 'nsdr-20',
       stateBefore: null,
-      stateAfter: 'clear',
+      stateAfter: null,
       timeWindowSelected: NSDR_20.timeWindow,
       durationActualSeconds: 1200,
       outcome: 'browse_launched',
       userChosenNextStep: null,
       intentPath: 'default',
       sessionStartedAt: 1_000_000,
+      reflectionId: 'calmer',
     });
   });
 
@@ -425,7 +444,8 @@ describe('mapBrowseTerminalToPayload — Case 4 schema mapping (no context)', ()
       sessionStartedAt: 1_000_000,
       sessionEndedAt: 1_000_000 + 1_200_000,
       durationActualSeconds: 1200,
-      stateAfter: 'clear',
+      stateAfter: null,
+      reflectionId: 'calmer',
       checkInFlowContext: null,
       userChosenNextStep: null,
     };
@@ -470,6 +490,8 @@ describe('mapBrowseTerminalToPayload — context-present (Bug B fix)', () => {
       sessionEndedAt: 1_000_000 + 1_200_000,
       durationActualSeconds: 1200,
       stateAfter,
+      // Check-in continuation path keeps the 5-state re-check, not a reflection.
+      reflectionId: null,
       checkInFlowContext: ctx,
       userChosenNextStep,
     };
@@ -581,7 +603,8 @@ describe('mapBrowseTerminalToPayload — context-present (Bug B fix)', () => {
       sessionStartedAt: 1_000_000,
       sessionEndedAt: 1_000_000 + 1_200_000,
       durationActualSeconds: 1200,
-      stateAfter: 'clear',
+      stateAfter: null,
+      reflectionId: 'calmer',
       checkInFlowContext: null,
       userChosenNextStep: null,
     };

--- a/mobile/src/components/checkin/flow/browseRunReducer.ts
+++ b/mobile/src/components/checkin/flow/browseRunReducer.ts
@@ -90,15 +90,12 @@ function reduceReCheck(
   state: Extract<BrowseRunFlowState, { step: 're_check' }>,
   action: BrowseRunFlowAction
 ): BrowseRunFlowState {
+  const ctx = state.checkInFlowContext;
+
+  // Check-in continuation path (ctx present) — the 5-state re-check feeds
+  // the response acknowledgment screen + transition classifier. Untouched
+  // by B-3b Issue 2 (the check-in-launched path keeps the 5-state vocab).
   if (action.type === 'state_after_selected') {
-    const ctx = state.checkInFlowContext;
-    // Round 12 (Finding H fix) — when ctx is present, the session is
-    // a CheckInFlow continuation and gets the standard response
-    // acknowledgment screen. When ctx is absent (true browse — no
-    // production entry today, reserved for future standalone
-    // Practices), preserve the sub-step 2.5 short-circuit straight
-    // to flow_complete (Case 4 spec: capture data and route, no
-    // further user choice).
     if (ctx) {
       return {
         step: 'response',
@@ -111,14 +108,25 @@ function reduceReCheck(
         checkInFlowContext: ctx,
       };
     }
+    // True browse no longer renders the 5-state re-check, so it never
+    // dispatches this. Defensive no-op (the reflection path is below).
+    return state;
+  }
+
+  // True-browse path (ctx absent) — B-3b Issue 2: the modern felt
+  // reflection replaces the 5-state re-check. The reflectionId is persisted
+  // as-is; NO stateAfter is synthesized from the chip. Case 4 short-circuit
+  // to flow_complete preserved (capture data and route, no response screen).
+  if (action.type === 'reflection_selected') {
     return {
       step: 'flow_complete',
       protocol: state.protocol,
       sessionStartedAt: state.sessionStartedAt,
       sessionEndedAt: state.sessionEndedAt,
       durationActualSeconds: state.durationActualSeconds,
-      stateAfter: action.stateAfter,
-      checkInFlowContext: null,
+      stateAfter: null,
+      reflectionId: action.reflectionId,
+      checkInFlowContext: ctx,
       userChosenNextStep: null,
     };
   }
@@ -137,6 +145,8 @@ function reduceResponse(
       sessionEndedAt: state.sessionEndedAt,
       durationActualSeconds: state.durationActualSeconds,
       stateAfter: state.stateAfter,
+      // Check-in continuation path records a 5-state re-check, not a reflection.
+      reflectionId: null,
       checkInFlowContext: state.checkInFlowContext,
       userChosenNextStep: action.choice,
     };
@@ -163,10 +173,13 @@ function reduceResponse(
 //     captured at the new `response` step. Replaces the prior always-
 //     null write that produced the round-2 'auto_dismissed' fragility.
 //
-//   - context ABSENT (true browse — no production entry as of round
-//     6; reachable only from dev harnesses) — preserves the original
-//     Case 4 mapping: stateBefore=null, outcome='browse_launched',
-//     userChosenNextStep=null (no response step renders without ctx).
+//   - context ABSENT (true browse — the Energy hub browse path, B-3b) —
+//     stateBefore=null, outcome='browse_launched', userChosenNextStep=null
+//     (no response step renders without ctx). B-3b Issue 2: the post-protocol
+//     step is now the modern felt reflection, so the row also carries
+//     `reflectionId` and stateAfter stays null (no 5-state is synthesized
+//     from the reflection chip). Existing browse_launched shape + reflectionId,
+//     NOT a new third shape.
 
 export function mapBrowseTerminalToPayload(
   terminal: BrowseTerminalFlowState,
@@ -207,15 +220,26 @@ export function mapBrowseTerminalToPayload(
   }
   // step === 'flow_complete'
   if (ctx) {
+    // Check-in continuation: the 5-state re-check → response step always
+    // carries a concrete BrainState (the null case below is unreachable for
+    // ctx-present flow_complete, guarded defensively rather than asserted).
+    const stateAfter = terminal.stateAfter;
+    if (stateAfter === null) {
+      return { ...base, stateAfter: null, outcome: 'browse_launched' };
+    }
     return {
       ...base,
-      stateAfter: terminal.stateAfter,
-      outcome: classifyOutcome(ctx.state, terminal.stateAfter),
+      stateAfter,
+      outcome: classifyOutcome(ctx.state, stateAfter),
     };
   }
+  // True browse (B-3b Issue 2): the existing browse_launched row shape PLUS
+  // the felt-reflection id. stateAfter stays null — the reflection chip is
+  // NOT mapped to a synthesized 5-state.
   return {
     ...base,
-    stateAfter: terminal.stateAfter,
+    stateAfter: null,
     outcome: 'browse_launched',
+    reflectionId: terminal.reflectionId,
   };
 }

--- a/mobile/src/components/checkin/flow/browseRunTypes.ts
+++ b/mobile/src/components/checkin/flow/browseRunTypes.ts
@@ -8,6 +8,12 @@
 // and flow_complete:
 //   running → re_check → response → flow_complete | abandoned (ctx)
 //   running → re_check → flow_complete | abandoned             (no ctx)
+// B-3b Issue 2: the `re_check` step now renders DIFFERENT views by ctx —
+// the deprecated 5-state ReCheckStepView for the check-in continuation
+// (ctx present), and the modern felt ReflectionStepView for true browse
+// (ctx absent). The state-machine shape above is unchanged; only the
+// ctx-absent transition carries a reflectionId (via `reflection_selected`)
+// instead of a synthesized stateAfter (via `state_after_selected`).
 //
 // Why the round-12 split: sub-step 2.5's original Case 4 design
 // assumed true-browse sessions (Practices-launched, no CheckInFlow
@@ -143,14 +149,16 @@ export interface BrowseResponseStep {
   checkInFlowContext: CheckInFlowContext;
 }
 
-// Terminal — re-check completed. Carries the captured stateAfter.
-// Parent observes step === 'flow_complete' and writes a
-// ProtocolSession; the outcome and stateBefore depend on
-// checkInFlowContext:
-//   - context present: outcome via classifyOutcome(context.state,
-//     stateAfter); stateBefore=context.state. Routing: dashboard.
-//   - context absent: outcome='browse_launched'; stateBefore=null.
-//     Routing: Practices index per SPEC_CONSISTENCY_BACKLOG
+// Terminal — re-check / reflection completed. The post-protocol
+// attestation differs by path (B-3b Issue 2):
+//   - context present (check-in continuation): the 5-state re-check ran,
+//     so `stateAfter` is a concrete BrainState and `reflectionId` is null.
+//     outcome via classifyOutcome(context.state, stateAfter);
+//     stateBefore=context.state. Routing: dashboard.
+//   - context absent (true browse): the modern felt reflection ran, so
+//     `reflectionId` is the chosen chip id and `stateAfter` is NULL (we do
+//     NOT synthesize a 5-state from the reflection). outcome='browse_launched';
+//     stateBefore=null. Routing: Practices index per SPEC_CONSISTENCY_BACKLOG
 //     "Case 4 routing target after re-check".
 export interface BrowseFlowCompleteStep {
   step: 'flow_complete';
@@ -158,7 +166,12 @@ export interface BrowseFlowCompleteStep {
   sessionStartedAt: number;
   sessionEndedAt: number;
   durationActualSeconds: number;
-  stateAfter: BrainState;
+  // Concrete BrainState on the check-in continuation path; null on true
+  // browse (reflection path) — no 5-state is synthesized from the chip.
+  stateAfter: BrainState | null;
+  // Felt-reflection chip id on the true-browse path; null on the check-in
+  // continuation path (which still records a 5-state re-check).
+  reflectionId: string | null;
   checkInFlowContext: CheckInFlowContext | null;
   // Round 12 (Finding H fix) — populated by `next_step_chosen`
   // when the response step ran (ctx-present continuation paths).
@@ -178,7 +191,11 @@ export interface BrowseFlowCompleteStep {
 
 export type BrowseRunFlowAction =
   | { type: 'player_exit'; reason: BrowseRunPlayerExitReason; nowMs: number }
+  // Check-in continuation path only (ctx present): the 5-state re-check.
   | { type: 'state_after_selected'; stateAfter: BrainState }
+  // True-browse path only (ctx absent): the modern felt reflection. Carries
+  // the chosen chip id; no BrainState is synthesized (B-3b Issue 2).
+  | { type: 'reflection_selected'; reflectionId: string }
   | { type: 'next_step_chosen'; choice: UserChosenNextStep };
 
 // ────────────────────────────────────────────────────────────

--- a/mobile/src/components/checkin/flow/reducer.ts
+++ b/mobile/src/components/checkin/flow/reducer.ts
@@ -42,7 +42,9 @@ import type { FlowAction, FlowInit, FlowState, ResolvedContext } from './types';
 
 // The reflection set keys on the slot direction; an `energize` practice reflects
 // via the energize set, everything else (settle / both / neutral) via settle.
-function slotDirectionForPractice(p: Protocol): SlotDirection {
+// Exported so the true-browse path (BrowseRunFlow) derives the same reflection
+// inputs the check-in loop uses, without forking a browse-specific variant.
+export function slotDirectionForPractice(p: Protocol): SlotDirection {
   return p.regulationDirection === 'energize' ? 'energize' : 'settle';
 }
 

--- a/mobile/src/components/protocol/GuidedSessionPlayer.tsx
+++ b/mobile/src/components/protocol/GuidedSessionPlayer.tsx
@@ -105,6 +105,13 @@ export interface GuidedSessionPlayerProps {
   onRecoveredSession?: (
     summary: ProtocolSessionSummary
   ) => Promise<void>;
+  // Fires when the user confirms exit at the PREROLL (idle) screen, before the
+  // session has started. There is no session to abandon, so this routes back
+  // without an abandoned-session write — distinct from mid-practice end-early,
+  // which goes through onExit. Optional and opt-in: callers that provide it
+  // (browse launches) get a working preroll exit; callers that omit it
+  // (check-in, onboarding) keep the existing behavior unchanged.
+  onExitBeforeStart?: () => void;
 }
 
 export function GuidedSessionPlayer({
@@ -112,6 +119,7 @@ export function GuidedSessionPlayer({
   stateBefore,
   onExit,
   onRecoveredSession,
+  onExitBeforeStart,
 }: GuidedSessionPlayerProps) {
   const reduceMotion = useReducedMotion();
 
@@ -413,11 +421,22 @@ export function GuidedSessionPlayer({
 
   const handleHeaderExitConfirm = useCallback(() => {
     setHeaderExitVisible(false);
+    // At the preroll (idle) there is no session to abandon: END_EARLY is a
+    // no-op at idle (playerReducer only abandons from running/paused), which
+    // is why the header X dead-ended here. If the caller provided an
+    // idle-exit handler (browse launches do), route back through it — no
+    // abandoned-session write. Otherwise fall through to the unchanged
+    // END_EARLY dispatch (still a no-op at idle for callers that don't opt
+    // in, preserving check-in/onboarding behavior).
+    if (state.status.kind === 'idle') {
+      onExitBeforeStart?.();
+      return;
+    }
     // Header X always uses user_exit, even during audio error. The
     // user actively chose to leave via the header — audio failure was
     // just the context.
     dispatch({ type: 'END_EARLY', nowMs: Date.now(), reason: 'user_exit' });
-  }, []);
+  }, [state.status.kind, onExitBeforeStart]);
 
   // ----- step dispatch -----
 

--- a/mobile/src/components/protocol/LightMovementProtocolFlow.tsx
+++ b/mobile/src/components/protocol/LightMovementProtocolFlow.tsx
@@ -60,6 +60,12 @@ export interface LightMovementProtocolFlowProps {
   // modality. Parent navigates back. No session write — none
   // started.
   onCancel: () => void;
+  // Fires when the user confirms exit at the player PREROLL (after picking a
+  // modality, before the timer starts). Threaded to GuidedSessionPlayer's
+  // onExitBeforeStart. Opt-in: only browse launches pass it, so check-in's
+  // brief-movement preroll behavior is unchanged. No session write — none
+  // started.
+  onExitBeforeStart?: () => void;
   // Round 3 (Layer 3) — the time window the user picked at the
   // chip step. Forwarded to the modality picker so it can render
   // the gap-acknowledgment line when the recommender returned a
@@ -94,6 +100,7 @@ export function LightMovementProtocolFlow({
   onExit,
   onModalitySelected,
   onCancel,
+  onExitBeforeStart,
   timeWindowSelected = null,
 }: LightMovementProtocolFlowProps) {
   const [selectedModality, setSelectedModality] =
@@ -126,6 +133,7 @@ export function LightMovementProtocolFlow({
       protocol={derivedProtocol}
       stateBefore={stateBefore}
       onExit={onExit}
+      onExitBeforeStart={onExitBeforeStart}
     />
   );
 }

--- a/mobile/src/components/protocol/__tests__/GuidedSessionPlayer.test.tsx
+++ b/mobile/src/components/protocol/__tests__/GuidedSessionPlayer.test.tsx
@@ -483,6 +483,48 @@ describe('GuidedSessionPlayer — exit reasons', () => {
     expect(onExit.mock.calls[0][0].abandonReason).toBe('user_exit');
   });
 
+  it('preroll (idle) X confirm calls onExitBeforeStart, not onExit (no session started)', async () => {
+    const onExit = jest.fn<void, [ProtocolSessionSummary]>();
+    const onExitBeforeStart = jest.fn<void, []>();
+    const { getByTestId } = render(
+      <GuidedSessionPlayer
+        protocol={singleInstruction}
+        stateBefore={null}
+        onExit={onExit}
+        onExitBeforeStart={onExitBeforeStart}
+        onRecoveredSession={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+    // Do NOT start — exit straight from the preroll.
+    fireEvent.press(getByTestId('player-header-close'));
+    fireEvent.press(getByTestId('end-early-modal-confirm'));
+
+    await waitFor(() => {
+      expect(onExitBeforeStart).toHaveBeenCalledTimes(1);
+    });
+    // No session was started, so no abandoned-session exit fires.
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('preroll (idle) X confirm without onExitBeforeStart is a no-op (preserves check-in/onboarding)', async () => {
+    const onExit = jest.fn<void, [ProtocolSessionSummary]>();
+    const { getByTestId, queryByTestId } = render(
+      <GuidedSessionPlayer
+        protocol={singleInstruction}
+        stateBefore="wired"
+        onExit={onExit}
+        onRecoveredSession={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+    fireEvent.press(getByTestId('player-header-close'));
+    fireEvent.press(getByTestId('end-early-modal-confirm'));
+
+    // No opt-in handler: END_EARLY is a no-op at idle, so onExit never fires
+    // and the player stays on the preroll (Begin button still present).
+    expect(onExit).not.toHaveBeenCalled();
+    expect(queryByTestId('player-idle-start')).not.toBeNull();
+  });
+
   it('transport End early in normal state dispatches with reason=user_exit', async () => {
     const onExit = jest.fn<void, [ProtocolSessionSummary]>();
     const { getByTestId } = render(


### PR DESCRIPTION
Four-Pillar IA **B-3b** browse-flow fixes. Three commits, in order, each green and bisectable; the branch fast-forwards cleanly onto current `main`.

## Commits (in sequence)
1. `4b1f8a2` **fix(player): make browse preroll exit leave the flow (B-3b Issue 1)** — browse preroll exit routes back out of the flow.
2. `8a26505` **feat(player): use felt reflection for true-browse completion (B-3b Issue 2)** — core swap.
3. `c273c50` **test(brand): guard Energy pillar screens against em-dash/optim* (B-3b)** — brandCopyGuard coverage.

## Issue 2 — what changed
Replaces the deprecated 5-state `ReCheckStepView` (Wired/Foggy/Steady/Clear/Alive) with the modern `ReflectionStepView` on the **true-browse** path (Energy hub → browse list → player), removing the last user-facing surface that exposed the old 5-state vocabulary and unifying browse with the check-in loop's post-session experience.

- `BrowseRunFlow` renders `ReflectionStepView` for true browse (ctx absent), deriving `pillar=protocol.pillar` and `direction=slotDirectionForPractice(protocol)` — the same component + props the check-in loop uses, no browse-specific fork (`slotDirectionForPractice` is now exported from the check-in reducer).
- The **check-in continuation** path (ctx present) is untouched: it keeps `ReCheckStepView` feeding the response screen + transition classifier. `ReCheckStepView` therefore remains in use (not deleted).
- New `reflection_selected` action; `re_check → flow_complete` persists the `reflectionId` and leaves `stateAfter` **null** (no synthesized 5-state).

### protocolSessions row shape (browse completion)
The existing `browse_launched` shape **plus** `reflectionId` — not a new third shape:

| Field | Before | After |
|---|---|---|
| `stateBefore` | `null` | `null` |
| `stateAfter` | synthesized 5-state | **`null`** |
| `outcome` | `browse_launched` | `browse_launched` |
| `userChosenNextStep` | `null` | `null` |
| `reflectionId` | _(absent)_ | **chosen chip id** |

## Brand guard
`brandCopyGuard` now also covers `EnergyHubScreen` and `EnergyBrowseListScreen`. The reflection labels surfaced on browse are the already-shipped check-in strings (`reflection.ts`) — no new unguarded copy.

## Verification
- **tsc: 167** (unchanged baseline, ≤167).
- **Tests:** `browseRunReducer` + `BrowseRunFlow` + `brandCopyGuard` green; broader check-in/practices/reflection sweep = 330 passing.
- **Device walk:** browse completion now shows "How does it feel now?" with felt-reflection chips, not the 5 brain-state rows.

> Merge with `--no-ff` per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)