### PR TITLE
feat(focus): Four-Pillar IA B-3c — Focus hub (launch wedge)

### DIFF
--- a/mobile/src/__tests__/brandCopyGuard.test.ts
+++ b/mobile/src/__tests__/brandCopyGuard.test.ts
@@ -37,6 +37,13 @@ const COPY_SOURCES = [
   // em dash / optim* in the rendered strings.
   'src/screens/Energy/EnergyHubScreen.tsx',
   'src/screens/Energy/EnergyBrowseListScreen.tsx',
+  // Four-Pillar IA Focus pillar (B-3c). The Focus hub + rhythms screens, the
+  // rhythms option labels, and the reworded focus reflection copy; guarded so
+  // the pillar rollout can't reintroduce an em dash / optim* in these strings.
+  'src/screens/Focus/FocusHubScreen.tsx',
+  'src/screens/Focus/FocusRhythmsScreen.tsx',
+  'src/constants/focusRhythms.ts',
+  'src/components/checkin/flow/reflection.ts',
 ];
 
 // U+2014 EM DASH, built via char code so no literal em-dash byte lives in

--- a/mobile/src/__tests__/brandCopyGuard.test.ts
+++ b/mobile/src/__tests__/brandCopyGuard.test.ts
@@ -42,6 +42,7 @@ const COPY_SOURCES = [
   // the pillar rollout can't reintroduce an em dash / optim* in these strings.
   'src/screens/Focus/FocusHubScreen.tsx',
   'src/screens/Focus/FocusRhythmsScreen.tsx',
+  'src/screens/Focus/components/CenterFirstToggle.tsx',
   'src/constants/focusRhythms.ts',
   'src/components/checkin/flow/reflection.ts',
 ];

--- a/mobile/src/components/checkin/flow/__tests__/reflection.test.ts
+++ b/mobile/src/components/checkin/flow/__tests__/reflection.test.ts
@@ -1,10 +1,30 @@
-import { reflectionSetFor, isStrongPositiveReflection } from '../reflection';
+import {
+  reflectionSetFor,
+  reflectionDisplayChips,
+  isStrongPositiveReflection,
+} from '../reflection';
 
 describe('reflectionSetFor — set chosen by (pillar, direction)', () => {
-  it('focus → Settled / Some / Still busy', () => {
+  it('focus → Stayed with it / Drifted some / Kept slipping', () => {
     const set = reflectionSetFor('focus', 'neutral');
-    expect(set.chips.map((c) => c.label)).toEqual(['Settled', 'Some', 'Still busy']);
+    expect(set.chips.map((c) => c.label)).toEqual([
+      'Stayed with it',
+      'Drifted some',
+      'Kept slipping',
+    ]);
+    // Persisted ids and the strong-positive marker are UNCHANGED — only the
+    // user-facing wording moves (outcome classification keys on these ids).
+    expect(set.chips.map((c) => c.id)).toEqual(['settled', 'some', 'still_busy']);
     expect(set.strongPositiveId).toBe('settled');
+  });
+
+  it('focus rendered chips carry the new labels on the stable ids', () => {
+    const chips = reflectionDisplayChips('focus', 'neutral');
+    expect(chips).toEqual([
+      { id: 'settled', label: 'Stayed with it' },
+      { id: 'some', label: 'Drifted some' },
+      { id: 'still_busy', label: 'Kept slipping' },
+    ]);
   });
 
   it('energy + settle → Calmer / A little calmer / Still wound up', () => {

--- a/mobile/src/components/checkin/flow/reflection.ts
+++ b/mobile/src/components/checkin/flow/reflection.ts
@@ -32,9 +32,9 @@ const FOCUS_SET: ReflectionSet = {
   direction: 'neutral',
   strongPositiveId: 'settled',
   chips: [
-    { id: 'settled', label: 'Settled' },
-    { id: 'some', label: 'Some' },
-    { id: 'still_busy', label: 'Still busy' },
+    { id: 'settled', label: 'Stayed with it' },
+    { id: 'some', label: 'Drifted some' },
+    { id: 'still_busy', label: 'Kept slipping' },
   ],
 };
 
@@ -148,7 +148,7 @@ const CATEGORY_LABELS: Record<ReflectionCategory, [string, string, string]> = {
   energize: ['More with it', 'A little more', 'Still flat'],
   settle_before_focus: ['Clearer', 'A little clearer', 'Still scattered'],
   rest: ['More rested', 'A little more', 'Still tense'],
-  focus: ['Settled', 'Some', 'Still busy'],
+  focus: ['Stayed with it', 'Drifted some', 'Kept slipping'],
 };
 
 /**

--- a/mobile/src/constants/focusRhythms.ts
+++ b/mobile/src/constants/focusRhythms.ts
@@ -1,0 +1,20 @@
+// Focus rhythms (Four-Pillar IA Phase B-3c). A quiet, opt-in capture of when
+// focus tends to come most easily for the user. Stored as time-of-day keys on
+// the user doc; nothing here is scored, counted, or tracked. Downstream use
+// (nudge / anchor timing) is intentionally out of scope for this slice.
+
+export interface FocusRhythmOption {
+  key: string;
+  label: string;
+}
+
+export const FOCUS_RHYTHM_OPTIONS: FocusRhythmOption[] = [
+  { key: 'early_morning', label: 'Early morning' },
+  { key: 'mid_morning', label: 'Mid-morning' },
+  { key: 'afternoon', label: 'Afternoon' },
+  { key: 'evening', label: 'Evening' },
+  { key: 'late_night', label: 'Late at night' },
+  { key: 'varies', label: 'It varies' },
+];
+
+export const FOCUS_RHYTHM_KEYS = FOCUS_RHYTHM_OPTIONS.map((o) => o.key);

--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -42,7 +42,7 @@ import {
 import DashboardScreen from '../screens/DashboardScreen';
 import MoreMenuScreen from '../screens/MoreMenuScreen';
 import PlanScreen from '../screens/PlanScreen';
-import { FocusScreen } from '../screens/Focus';
+import { FocusScreen, FocusHubScreen } from '../screens/Focus';
 import JournalScreen from '../screens/JournalScreen';
 import InsightsScreen from '../screens/InsightsScreen';
 import ProfileScreen from '../screens/ProfileScreen';
@@ -543,15 +543,15 @@ const BottomTabsNavigator = () => {
  *
  * Tabs / placeholder destinations:
  *   Home      → DashboardScreen     (unchanged)
- *   Focus     → FocusScreen         (existing pomodoro, for now)
+ *   Focus     → FocusHubScreen      (B-3c hub; primary card opens FocusTimer)
  *   Energy    → EnergyHubPlaceholder (scaffold stub; real hub is B-3b)
  *   Time      → PlanScreen          (existing habits + routines, for now)
  *   Community → CommunityNavigator  (unchanged)
  *
  * FAB: matches each tab's current equivalent — Home/Time/Community show it, and
- * Focus shows it (the FocusTimer screen does today). Energy is intentionally
- * no-FAB: a browse hub does not host the AI assistant CTA. Revisit when the
- * real Energy hub lands in B-3b.
+ * Focus keeps it (the FocusHubScreen tab, B-3c). Energy is intentionally
+ * no-FAB: a browse hub does not host the AI assistant CTA. (The Focus-hub FAB
+ * disposition is unchanged in B-3c; any Guide-pill migration is a later slice.)
  *
  * Icons for Focus/Energy/Time are approximate scaffold placeholders
  * (timer-outline / lightning-bolt / clock-outline) — refine in B-3b.
@@ -590,7 +590,7 @@ const FivePillarTabs = () => {
       />
       <BottomTabs.Screen
         name={ROUTES.PillarFocus}
-        component={FocusScreen}
+        component={FocusHubScreen}
         options={tabOpts({
           tabBarLabel: 'Focus',
           tabBarIcon: ({ color, size }) => (

--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -42,7 +42,7 @@ import {
 import DashboardScreen from '../screens/DashboardScreen';
 import MoreMenuScreen from '../screens/MoreMenuScreen';
 import PlanScreen from '../screens/PlanScreen';
-import { FocusScreen, FocusHubScreen } from '../screens/Focus';
+import { FocusScreen, FocusHubScreen, FocusRhythmsScreen } from '../screens/Focus';
 import JournalScreen from '../screens/JournalScreen';
 import InsightsScreen from '../screens/InsightsScreen';
 import ProfileScreen from '../screens/ProfileScreen';
@@ -928,6 +928,23 @@ const MainNavigator = () => {
               ...standardHeaderOptions,
               animation: 'slide_from_right',
               headerShown: true,
+              headerShadowVisible: false,
+              showFAB: false,
+            })}
+          />
+        )}
+        {/* Four-Pillar IA Phase B-3c — Focus rhythms. Flag-gated like the Energy
+            hub browse list. The Focus tab (PillarFocus → FocusHubScreen)
+            navigates here; it is a quiet opt-in capture, so showFAB stays off. */}
+        {FOUR_PILLAR_IA && (
+          <AppStack.Screen
+            name={ROUTES.FocusRhythms}
+            component={FocusRhythmsScreen}
+            options={stackOpts({
+              ...standardHeaderOptions,
+              animation: 'slide_from_right',
+              headerShown: true,
+              title: 'Focus rhythms',
               headerShadowVisible: false,
               showFAB: false,
             })}

--- a/mobile/src/navigation/routes.ts
+++ b/mobile/src/navigation/routes.ts
@@ -40,6 +40,10 @@ export const ROUTES = {
   // EnergyHubScreen). Parameterized by browseCategory (regulate/rest/fuel).
   // Registered in the flag-ON AppStack path only.
   EnergyBrowse: 'EnergyBrowse',
+  // Focus hub (B-3c) secondary entry, reached from the Focus tab (PillarFocus →
+  // FocusHubScreen). A quiet capture of when focus comes easiest; no scores.
+  // Registered in the flag-ON AppStack path only.
+  FocusRhythms: 'FocusRhythms',
 
   // --- Root / AppStack (MainNavigator) ---
   Main: 'Main',

--- a/mobile/src/screens/Focus/FocusHubScreen.tsx
+++ b/mobile/src/screens/Focus/FocusHubScreen.tsx
@@ -22,7 +22,7 @@ import { ROUTES } from '../../navigation/routes';
 const MIN_TOUCH_TARGET = 48;
 
 type NavigationProp = NativeStackNavigationProp<{
-  FocusTimer: undefined;
+  FocusTimer: { fromHub?: boolean } | undefined;
   FocusRhythms: undefined;
 }>;
 
@@ -39,7 +39,7 @@ export function FocusHubScreen() {
             rule). Opens the existing Pomodoro timer. */}
         <TouchableOpacity
           style={styles.primaryCard}
-          onPress={() => navigation.navigate(ROUTES.FocusTimer)}
+          onPress={() => navigation.navigate(ROUTES.FocusTimer, { fromHub: true })}
           accessibilityRole="button"
           accessibilityLabel="Set a focus. Choose a length and give a single task your full attention."
           testID="focus-hub-card-primary"

--- a/mobile/src/screens/Focus/FocusHubScreen.tsx
+++ b/mobile/src/screens/Focus/FocusHubScreen.tsx
@@ -1,0 +1,147 @@
+// Focus hub — Four-Pillar IA Phase B-3c (the launch wedge).
+//
+// Replaces FocusScreen as the PillarFocus tab root. A calm home with a single
+// primary action: set a focus, which opens the existing Pomodoro timer
+// (FocusTimer stack screen). A quieter secondary entry captures when focus
+// comes easiest (FocusRhythmsScreen).
+//
+// Built to the EnergyHubScreen precedent. No streaks, no counts, no stats: the
+// only outcome is a felt one, surfaced by the post-timer reflection, never a
+// metric on this page.
+
+import React from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+
+import { Colors, Spacing, TextStyles, Typography } from '../../constants';
+import { ROUTES } from '../../navigation/routes';
+
+const MIN_TOUCH_TARGET = 48;
+
+type NavigationProp = NativeStackNavigationProp<{
+  FocusTimer: undefined;
+  FocusRhythms: undefined;
+}>;
+
+export function FocusHubScreen() {
+  const navigation = useNavigation<NavigationProp>();
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <ScrollView contentContainerStyle={styles.content} testID="focus-hub">
+        <Text style={styles.title}>Focus</Text>
+        <Text style={styles.intro}>Protected time for one thing at a time.</Text>
+
+        {/* Primary action: whole-card tappable (no inner button, per the card
+            rule). Opens the existing Pomodoro timer. */}
+        <TouchableOpacity
+          style={styles.primaryCard}
+          onPress={() => navigation.navigate(ROUTES.FocusTimer)}
+          accessibilityRole="button"
+          accessibilityLabel="Set a focus. Choose a length and give a single task your full attention."
+          testID="focus-hub-card-primary"
+        >
+          <Text style={styles.primaryEyebrow}>Deep work</Text>
+          <Text style={styles.primaryHeading}>Set a focus</Text>
+          <Text style={styles.primaryBody}>
+            Choose a length, settle in if you need to, and give a single task
+            your full attention.
+          </Text>
+        </TouchableOpacity>
+
+        {/* Secondary, quieter list-item entry. */}
+        <TouchableOpacity
+          style={styles.secondaryCard}
+          onPress={() => navigation.navigate(ROUTES.FocusRhythms)}
+          accessibilityRole="button"
+          accessibilityLabel="Focus rhythms. Notice when focus comes easiest for you."
+          testID="focus-hub-card-rhythms"
+        >
+          <View style={styles.secondaryText}>
+            <Text style={styles.secondaryLabel}>Focus rhythms</Text>
+            <Text style={styles.secondaryDescriptor}>
+              Notice when focus comes easiest for you.
+            </Text>
+          </View>
+          <Icon name="chevron-right" size={24} color={Colors.mutedSageGray} />
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.background.default,
+  },
+  content: {
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.lg,
+    paddingBottom: Spacing.xl,
+  },
+  title: {
+    ...TextStyles.h1,
+    color: Colors.evergreenTeal,
+    marginBottom: Spacing.xs,
+  },
+  intro: {
+    ...TextStyles.body,
+    color: Colors.mutedSageGray,
+    marginBottom: Spacing.xl,
+  },
+  primaryCard: {
+    padding: Spacing.lg,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: Colors.divider,
+    backgroundColor: Colors.surface,
+    marginBottom: Spacing.md,
+  },
+  primaryEyebrow: {
+    fontSize: 12,
+    fontWeight: Typography.fontWeight.semibold,
+    letterSpacing: 0.72,
+    textTransform: 'uppercase',
+    color: Colors.evergreenTeal,
+    marginBottom: 6,
+  },
+  primaryHeading: {
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.softCharcoal,
+    marginBottom: 8,
+  },
+  primaryBody: {
+    ...TextStyles.body,
+    color: Colors.mutedSageGray,
+  },
+  secondaryCard: {
+    minHeight: MIN_TOUCH_TARGET,
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: Spacing.lg,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: Colors.divider,
+    backgroundColor: Colors.surface,
+  },
+  secondaryText: {
+    flex: 1,
+  },
+  secondaryLabel: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.softCharcoal,
+    marginBottom: 2,
+  },
+  secondaryDescriptor: {
+    ...TextStyles.bodySmall,
+    color: Colors.mutedSageGray,
+  },
+});
+
+export default FocusHubScreen;

--- a/mobile/src/screens/Focus/FocusRhythmsScreen.tsx
+++ b/mobile/src/screens/Focus/FocusRhythmsScreen.tsx
@@ -1,0 +1,196 @@
+// Focus rhythms (Four-Pillar IA Phase B-3c). Reached from the Focus hub. A
+// calm, opt-in, MULTI-select capture of when focus tends to come most easily.
+// Selections persist as plain time-of-day keys on the user doc; nothing here is
+// tracked or scored. Downstream use (nudge / anchor timing) is out of scope.
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+
+import { Colors, Spacing, TextStyles, Typography } from '../../constants';
+import { FOCUS_RHYTHM_OPTIONS } from '../../constants/focusRhythms';
+import { useAuth } from '../../context/AuthContext';
+import {
+  getFocusRhythms,
+  saveFocusRhythms,
+} from '../../services/firebase/focusRhythms.service';
+import { logger } from '../../utils/logger';
+
+const MIN_TOUCH_TARGET = 48;
+
+export function FocusRhythmsScreen() {
+  const navigation = useNavigation<{ goBack: () => void }>();
+  const { user } = useAuth();
+  const [selected, setSelected] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  // Pre-select the user's previously saved windows so re-entry shows prior
+  // choices. Best-effort: a read failure just leaves the form empty.
+  useEffect(() => {
+    let active = true;
+    if (!user) return;
+    getFocusRhythms(user.uid)
+      .then((windows) => {
+        if (active) setSelected(windows);
+      })
+      .catch((error) => logger.error('[FocusRhythms] load failed:', error));
+    return () => {
+      active = false;
+    };
+  }, [user]);
+
+  const toggle = useCallback((key: string) => {
+    setSelected((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]
+    );
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!user || saving) {
+      if (!user) navigation.goBack();
+      return;
+    }
+    setSaving(true);
+    try {
+      await saveFocusRhythms(user.uid, selected);
+    } catch (error) {
+      logger.error('[FocusRhythms] save failed:', error);
+    } finally {
+      navigation.goBack();
+    }
+  }, [user, saving, selected, navigation]);
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <ScrollView contentContainerStyle={styles.content} testID="focus-rhythms">
+        <Text style={styles.intro}>
+          When does focus tend to come most easily? Noticing your natural rhythms
+          can help you plan around them.
+        </Text>
+        <Text style={styles.cue}>Pick any that fit.</Text>
+
+        <View style={styles.options}>
+          {FOCUS_RHYTHM_OPTIONS.map((opt) => {
+            const checked = selected.includes(opt.key);
+            return (
+              <TouchableOpacity
+                key={opt.key}
+                style={styles.option}
+                onPress={() => toggle(opt.key)}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked }}
+                accessibilityLabel={opt.label}
+                testID={`focus-rhythm-option-${opt.key}`}
+              >
+                <View style={[styles.checkbox, checked && styles.checkboxChecked]}>
+                  {checked && (
+                    <Icon name="check" size={16} color={Colors.surface} />
+                  )}
+                </View>
+                <Text style={styles.optionLabel}>{opt.label}</Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        <Text style={styles.note}>
+          Just for you. Nothing here is tracked or scored.
+        </Text>
+
+        <TouchableOpacity
+          style={styles.saveButton}
+          onPress={handleSave}
+          accessibilityRole="button"
+          accessibilityLabel="Save"
+          testID="focus-rhythms-save"
+        >
+          <Text style={styles.saveLabel}>Save</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.background.default,
+  },
+  content: {
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.lg,
+    paddingBottom: Spacing.xl,
+  },
+  intro: {
+    ...TextStyles.body,
+    color: Colors.softCharcoal,
+    marginBottom: Spacing.sm,
+  },
+  cue: {
+    ...TextStyles.bodySmall,
+    color: Colors.mutedSageGray,
+    marginBottom: Spacing.lg,
+  },
+  options: {
+    gap: Spacing.sm,
+  },
+  option: {
+    minHeight: MIN_TOUCH_TARGET,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: Colors.divider,
+    backgroundColor: Colors.surface,
+  },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: 1.5,
+    borderColor: Colors.mutedSageGray,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: Spacing.md,
+  },
+  checkboxChecked: {
+    backgroundColor: Colors.evergreenTeal,
+    borderColor: Colors.evergreenTeal,
+  },
+  optionLabel: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.softCharcoal,
+  },
+  note: {
+    ...TextStyles.bodySmall,
+    color: Colors.mutedSageGray,
+    marginTop: Spacing.lg,
+    marginBottom: Spacing.lg,
+  },
+  saveButton: {
+    minHeight: MIN_TOUCH_TARGET,
+    borderRadius: 14,
+    backgroundColor: Colors.evergreenTeal,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: Spacing.md,
+  },
+  saveLabel: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.surface,
+  },
+});
+
+export default FocusRhythmsScreen;

--- a/mobile/src/screens/Focus/FocusScreen.tsx
+++ b/mobile/src/screens/Focus/FocusScreen.tsx
@@ -14,10 +14,20 @@
  * pillar's state-less, neutral-direction set, and stateBefore/stateAfter are
  * never synthesized for a bare timer session.
  *
+ * Center first (B-3c commit 5): an opt-in, remembered row on the timer setup
+ * runs a FIXED pre-focus practice (box breathing, 2 min) before the timer. It
+ * is launched HUB-LOCALLY here via GuidedSessionPlayer — a real protocol with a
+ * normal protocolSession row — NOT through the check-in plan resolver, the
+ * quadrant ranker, or the shared PracticeRunScreen completion path. On the
+ * practice's completion we hand off straight into the (auto-started) timer; the
+ * single end-of-loop reflection stays the FOCUS reflection. No BrainState is
+ * synthesized: the box breathing run captures stateBefore=null, and the timer
+ * session in focusSessions stays state-less and protocol-less, unchanged.
+ *
  * Routines have been relocated to the Track page.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
@@ -26,10 +36,23 @@ import { doc, updateDoc, serverTimestamp } from 'firebase/firestore';
 
 import { ColorTokens, SpacingTokens } from '../../constants/designTokens';
 import { FocusCopy } from '../../constants/focusContent';
+import { getProtocolById } from '../../constants/brainStateProtocols';
 import { db } from '../../config/firebase';
 import { logger } from '../../utils/logger';
+import { useAuth } from '../../context/AuthContext';
 import { ReflectionStepView } from '../../components/checkin/flow/ReflectionStepView';
+import { GuidedSessionPlayer } from '../../components/protocol/GuidedSessionPlayer';
+import {
+  getFocusPreferences,
+  saveFocusPreferences,
+} from '../../services/firebase/focusPreferences.service';
+import { writeProtocolSession } from '../../services/firebase/protocolSession.service';
+import type { ProtocolSessionSummary } from '../../types/models';
 import { PomodoroTab } from './PomodoroTab';
+
+// The fixed pre-focus practice. A real regulate protocol (2-min box breathing);
+// launched as a known, hardcoded id — never resolved from state.
+const CENTER_FIRST_PROTOCOL_ID = 'box-breathing-2';
 
 type FocusRoute = RouteProp<
   {
@@ -43,6 +66,7 @@ type FocusRoute = RouteProp<
 export const FocusScreen: React.FC = () => {
   const route = useRoute<FocusRoute>();
   const navigation = useNavigation();
+  const { user } = useAuth();
   const fromCheckIn = route.params?.fromCheckIn === true;
   // Hub-launched sessions (B-3c) chain into the focus reflection too, via an
   // explicit param so check-in's behavior is never overloaded.
@@ -56,6 +80,87 @@ export const FocusScreen: React.FC = () => {
   // reflection to (may be null if no block completed / no db).
   const [reflecting, setReflecting] = useState(false);
   const [focusSessionId, setFocusSessionId] = useState<string | null>(null);
+
+  // Center-first state. `centerFirst` controls the setup row (initialized from
+  // the persisted preference). `centering` flips while the box breathing
+  // practice runs. `centeredDone` makes centering a once-per-session affordance.
+  // `centeredDuration`/`autoStartTimer` carry the user's picked length and the
+  // auto-start signal across the centering handoff.
+  const [centerFirst, setCenterFirst] = useState(false);
+  const [centering, setCentering] = useState(false);
+  const [centeredDone, setCenteredDone] = useState(false);
+  const [centeredDuration, setCenteredDuration] = useState<number | undefined>(
+    undefined
+  );
+  const [autoStartTimer, setAutoStartTimer] = useState(false);
+  // Once the user toggles the row, an in-flight preference load must not clobber
+  // their choice.
+  const userToggledRef = useRef(false);
+
+  const centerProtocol = getProtocolById(CENTER_FIRST_PROTOCOL_ID);
+  const canCenter = !!centerProtocol && !centeredDone;
+
+  // Load the remembered Center-first choice.
+  useEffect(() => {
+    if (!user?.uid) return;
+    let active = true;
+    getFocusPreferences(user.uid)
+      .then((prefs) => {
+        if (active && !userToggledRef.current) setCenterFirst(prefs.centerFirst);
+      })
+      .catch((error) => logger.error('[FocusScreen] prefs load failed:', error));
+    return () => {
+      active = false;
+    };
+  }, [user]);
+
+  const handleToggleCenterFirst = useCallback(
+    (next: boolean) => {
+      userToggledRef.current = true;
+      setCenterFirst(next);
+      if (user?.uid) {
+        saveFocusPreferences(user.uid, { centerFirst: next }).catch((error) =>
+          logger.error('[FocusScreen] prefs save failed:', error)
+        );
+      }
+    },
+    [user]
+  );
+
+  // Begin tapped with Center-first ON → run the fixed pre-focus practice. The
+  // picked length is held so the post-centering timer opens at the same budget.
+  const handleCenterFirstBegin = useCallback((durationMinutes: number) => {
+    setCenteredDuration(durationMinutes);
+    setCentering(true);
+  }, []);
+
+  // Box breathing finished (natural completion or mid-practice exit). Persist a
+  // NORMAL, state-less protocolSession row for the practice (its own record,
+  // separate from the focusSessions timer doc), then hand off to the timer.
+  // Auto-start it only on a real completion; an early exit returns to the setup.
+  const handleCenterExit = useCallback(
+    (summary: ProtocolSessionSummary) => {
+      if (user?.uid && centerProtocol) {
+        writeProtocolSession(user.uid, {
+          protocolId: summary.protocolId,
+          stateBefore: null,
+          stateAfter: null,
+          timeWindowSelected: centerProtocol.timeWindow,
+          durationActualSeconds: summary.durationActualSeconds,
+          outcome: summary.completed ? 'browse_launched' : 'abandoned',
+          userChosenNextStep: null,
+          intentPath: 'default',
+          sessionStartedAt: summary.startedAt,
+        }).catch((error) =>
+          logger.error('[FocusScreen] center session write failed:', error)
+        );
+      }
+      setCentering(false);
+      setCenteredDone(true);
+      setAutoStartTimer(summary.completed);
+    },
+    [user, centerProtocol]
+  );
 
   const handleLoopDone = useCallback((id: string | null) => {
     setFocusSessionId(id);
@@ -94,6 +199,21 @@ export const FocusScreen: React.FC = () => {
     );
   }
 
+  // Centering phase: run the fixed pre-focus practice. Hub-local — its own
+  // GuidedSessionPlayer with no terminal reflection and no route-home; on exit
+  // handleCenterExit hands off to the timer below.
+  if (centering && centerProtocol) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <GuidedSessionPlayer
+          protocol={centerProtocol}
+          stateBefore={null}
+          onExit={handleCenterExit}
+        />
+      </SafeAreaView>
+    );
+  }
+
   return (
     <SafeAreaView style={styles.container} edges={[]}>
       <View style={styles.header}>
@@ -103,7 +223,11 @@ export const FocusScreen: React.FC = () => {
       <View style={styles.content}>
         <PomodoroTab
           showAdvancedDuration
-          initialDuration={initialDuration}
+          initialDuration={centeredDuration ?? initialDuration}
+          autoStart={autoStartTimer}
+          centerFirst={centerFirst}
+          onToggleCenterFirst={handleToggleCenterFirst}
+          onCenterFirstBegin={canCenter ? handleCenterFirstBegin : undefined}
           onLoopDone={chainReflection ? handleLoopDone : undefined}
         />
       </View>

--- a/mobile/src/screens/Focus/FocusScreen.tsx
+++ b/mobile/src/screens/Focus/FocusScreen.tsx
@@ -3,11 +3,16 @@
  * Pomodoro focus screen.
  *
  * Closes the focus-session loop (Vara_Engine_Contract.md §12.1): when this
- * screen is reached FROM the check-in loop (route param `fromCheckIn`), tapping
- * "Done for now" on the Pomodoro returns to the Focus reflection (the §9 focus
- * chip set) before exiting home — the same exit a catalog-practice reflection
- * uses. A directly-started Pomodoro (no `fromCheckIn`) pops no reflection. The
- * return is guarded on the explicit launch param, never any global state.
+ * screen is reached FROM the check-in loop (route param `fromCheckIn`) OR from
+ * the Focus hub (route param `fromHub`, B-3c), tapping "Done for now" on the
+ * Pomodoro returns to the Focus reflection (the §9 focus chip set) before
+ * exiting home — the same exit a catalog-practice reflection uses. A
+ * directly-started Pomodoro (neither param) pops no reflection. The return is
+ * guarded on the explicit launch params, never any global state.
+ *
+ * The focus reflection carries no protocol and no BrainState: it is the focus
+ * pillar's state-less, neutral-direction set, and stateBefore/stateAfter are
+ * never synthesized for a bare timer session.
  *
  * Routines have been relocated to the Track page.
  */
@@ -27,7 +32,11 @@ import { ReflectionStepView } from '../../components/checkin/flow/ReflectionStep
 import { PomodoroTab } from './PomodoroTab';
 
 type FocusRoute = RouteProp<
-  { FocusTimer: { fromCheckIn?: boolean; durationMinutes?: number } | undefined },
+  {
+    FocusTimer:
+      | { fromCheckIn?: boolean; fromHub?: boolean; durationMinutes?: number }
+      | undefined;
+  },
   'FocusTimer'
 >;
 
@@ -35,6 +44,10 @@ export const FocusScreen: React.FC = () => {
   const route = useRoute<FocusRoute>();
   const navigation = useNavigation();
   const fromCheckIn = route.params?.fromCheckIn === true;
+  // Hub-launched sessions (B-3c) chain into the focus reflection too, via an
+  // explicit param so check-in's behavior is never overloaded.
+  const fromHub = route.params?.fromHub === true;
+  const chainReflection = fromCheckIn || fromHub;
   // Budget-derived prefill length from the check-in's focus-session pointer.
   const initialDuration = route.params?.durationMinutes;
 
@@ -68,7 +81,7 @@ export const FocusScreen: React.FC = () => {
     [focusSessionId, navigation]
   );
 
-  if (fromCheckIn && reflecting) {
+  if (chainReflection && reflecting) {
     return (
       <SafeAreaView style={styles.container} edges={['top']}>
         <ReflectionStepView
@@ -91,7 +104,7 @@ export const FocusScreen: React.FC = () => {
         <PomodoroTab
           showAdvancedDuration
           initialDuration={initialDuration}
-          onLoopDone={fromCheckIn ? handleLoopDone : undefined}
+          onLoopDone={chainReflection ? handleLoopDone : undefined}
         />
       </View>
     </SafeAreaView>

--- a/mobile/src/screens/Focus/PomodoroTab.tsx
+++ b/mobile/src/screens/Focus/PomodoroTab.tsx
@@ -35,7 +35,9 @@ import {
   NotificationToggle,
   AmbientSoundSelector,
 } from './components';
+import { CenterFirstToggle } from './components/CenterFirstToggle';
 import { TimerRing } from '../../components/shared/TimerRing';
+import { resolvePlayAction } from './centerFirst';
 
 const TASK_LABEL_KEY = '@focus_task_label';
 
@@ -57,12 +59,28 @@ interface PomodoroTabProps {
    * Pomodoro, which pops no reflection.
    */
   onLoopDone?: (focusSessionId: string | null) => void;
+  /**
+   * B-3c "Center first" wiring. `centerFirst` controls the opt-in setup row
+   * (shown only when `onToggleCenterFirst` is provided). When `onCenterFirstBegin`
+   * is supplied AND the row is on, the idle Begin tap launches the pre-focus
+   * practice instead of starting the timer (the parent owns that handoff). When
+   * `autoStart` is true the timer starts on mount — used when the parent hands
+   * back from the centering practice so no second tap is needed.
+   */
+  centerFirst?: boolean;
+  onToggleCenterFirst?: (next: boolean) => void;
+  onCenterFirstBegin?: (durationMinutes: number) => void;
+  autoStart?: boolean;
 }
 
 export const PomodoroTab: React.FC<PomodoroTabProps> = ({
   showAdvancedDuration = true,
   initialDuration,
   onLoopDone,
+  centerFirst = false,
+  onToggleCenterFirst,
+  onCenterFirstBegin,
+  autoStart = false,
 }) => {
   const { user } = useAuth();
   const { playCompletionSound } = useCompletionSound();
@@ -170,14 +188,35 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
   }, [timer]);
 
   const handlePlayPause = useCallback(() => {
-    if (timer.state === 'idle') {
-      timer.start();
-    } else if (timer.state === 'running' || timer.state === 'break_running') {
-      timer.pause();
-    } else if (timer.state === 'paused') {
-      timer.resume();
+    const action = resolvePlayAction(timer.state, {
+      centerFirst,
+      canCenter: !!onCenterFirstBegin,
+    });
+    switch (action) {
+      case 'center':
+        // Hand off to the parent's pre-focus practice instead of starting.
+        onCenterFirstBegin?.(selectedDuration);
+        return;
+      case 'start':
+        timer.start();
+        return;
+      case 'pause':
+        timer.pause();
+        return;
+      case 'resume':
+        timer.resume();
+        return;
     }
-  }, [timer]);
+  }, [timer, centerFirst, onCenterFirstBegin, selectedDuration]);
+
+  // Auto-start when handed back from the centering practice (no second tap).
+  // Mount-only; the small delay mirrors handleStartAnother's reset→start gap.
+  useEffect(() => {
+    if (!autoStart) return;
+    const id = setTimeout(() => timer.start(), 50);
+    return () => clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleStartAnother = useCallback(() => {
     timer.reset();
@@ -265,6 +304,11 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
         disabled={timer.isActive}
         showAdvanced={showAdvancedDuration}
       />
+
+      {/* Center first — opt-in pre-focus practice (B-3c). Setup only. */}
+      {onToggleCenterFirst && timer.state === 'idle' && (
+        <CenterFirstToggle value={centerFirst} onToggle={onToggleCenterFirst} />
+      )}
 
       {/* Timer Ring */}
       <View style={styles.timerContainer}>

--- a/mobile/src/screens/Focus/__tests__/FocusHubScreen.test.tsx
+++ b/mobile/src/screens/Focus/__tests__/FocusHubScreen.test.tsx
@@ -39,10 +39,11 @@ describe('FocusHubScreen', () => {
     ).toBeTruthy();
   });
 
-  it('tapping the primary card opens the focus timer', () => {
+  it('tapping the primary card opens the focus timer, flagged as hub-launched', () => {
     const { getByTestId } = render(<FocusHubScreen />);
     fireEvent.press(getByTestId('focus-hub-card-primary'));
-    expect(mockNavigate).toHaveBeenCalledWith('FocusTimer');
+    // fromHub chains the timer into the focus reflection on completion (commit 3).
+    expect(mockNavigate).toHaveBeenCalledWith('FocusTimer', { fromHub: true });
   });
 
   it('shows the secondary "Focus rhythms" entry and routes to it', () => {

--- a/mobile/src/screens/Focus/__tests__/FocusHubScreen.test.tsx
+++ b/mobile/src/screens/Focus/__tests__/FocusHubScreen.test.tsx
@@ -1,0 +1,61 @@
+// Focus hub (Four-Pillar IA Phase B-3c). The PillarFocus tab root: a calm home
+// with one primary action (set a focus → the timer) and a quieter secondary
+// entry (focus rhythms). No streaks, no counts, no stats.
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: any) => {
+    const { View } = require('react-native');
+    return <View>{children}</View>;
+  },
+}));
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { FocusHubScreen } from '../FocusHubScreen';
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+});
+
+describe('FocusHubScreen', () => {
+  it('renders the title and calm subtitle', () => {
+    const { getByText } = render(<FocusHubScreen />);
+    expect(getByText('Focus')).toBeTruthy();
+    expect(getByText('Protected time for one thing at a time.')).toBeTruthy();
+  });
+
+  it('shows the primary "Set a focus" card with eyebrow + body', () => {
+    const { getByText } = render(<FocusHubScreen />);
+    expect(getByText('Deep work')).toBeTruthy();
+    expect(getByText('Set a focus')).toBeTruthy();
+    expect(
+      getByText(
+        'Choose a length, settle in if you need to, and give a single task your full attention.'
+      )
+    ).toBeTruthy();
+  });
+
+  it('tapping the primary card opens the focus timer', () => {
+    const { getByTestId } = render(<FocusHubScreen />);
+    fireEvent.press(getByTestId('focus-hub-card-primary'));
+    expect(mockNavigate).toHaveBeenCalledWith('FocusTimer');
+  });
+
+  it('shows the secondary "Focus rhythms" entry and routes to it', () => {
+    const { getByText, getByTestId } = render(<FocusHubScreen />);
+    expect(getByText('Focus rhythms')).toBeTruthy();
+    expect(getByText('Notice when focus comes easiest for you.')).toBeTruthy();
+    fireEvent.press(getByTestId('focus-hub-card-rhythms'));
+    expect(mockNavigate).toHaveBeenCalledWith('FocusRhythms');
+  });
+
+  it('has no streak / count / stats language', () => {
+    const { queryByText } = render(<FocusHubScreen />);
+    expect(queryByText(/streak/i)).toBeNull();
+    expect(queryByText(/sessions today/i)).toBeNull();
+  });
+});

--- a/mobile/src/screens/Focus/__tests__/FocusRhythmsScreen.test.tsx
+++ b/mobile/src/screens/Focus/__tests__/FocusRhythmsScreen.test.tsx
@@ -1,0 +1,83 @@
+// Focus rhythms (Four-Pillar IA Phase B-3c). A multi-select capture of when
+// focus comes easiest. Opt-in, nothing scored. Reached from the Focus hub.
+
+const mockGoBack = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: mockGoBack }),
+}));
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: any) => {
+    const { View } = require('react-native');
+    return <View>{children}</View>;
+  },
+}));
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { uid: 'u1' } }),
+}));
+
+const mockSave = jest.fn((..._a: any[]) => Promise.resolve());
+const mockGet = jest.fn((..._a: any[]) => Promise.resolve([] as string[]));
+jest.mock('../../../services/firebase/focusRhythms.service', () => ({
+  saveFocusRhythms: (...a: any[]) => mockSave(...a),
+  getFocusRhythms: (...a: any[]) => mockGet(...a),
+}));
+
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { FocusRhythmsScreen } from '../FocusRhythmsScreen';
+
+beforeEach(() => {
+  mockGoBack.mockClear();
+  mockSave.mockClear();
+  mockGet.mockReset();
+  mockGet.mockResolvedValue([]);
+});
+
+describe('FocusRhythmsScreen', () => {
+  it('renders the intro, cue, options, the quiet note, and Save', () => {
+    const { getByText } = render(<FocusRhythmsScreen />);
+    expect(
+      getByText(
+        'When does focus tend to come most easily? Noticing your natural rhythms can help you plan around them.'
+      )
+    ).toBeTruthy();
+    expect(getByText('Pick any that fit.')).toBeTruthy();
+    expect(getByText('Early morning')).toBeTruthy();
+    expect(getByText('It varies')).toBeTruthy();
+    expect(getByText('Just for you. Nothing here is tracked or scored.')).toBeTruthy();
+    expect(getByText('Save')).toBeTruthy();
+  });
+
+  it('is multi-select: more than one option can be active at once', () => {
+    const { getByTestId } = render(<FocusRhythmsScreen />);
+    fireEvent.press(getByTestId('focus-rhythm-option-early_morning'));
+    fireEvent.press(getByTestId('focus-rhythm-option-evening'));
+    expect(getByTestId('focus-rhythm-option-early_morning').props.accessibilityState.checked).toBe(true);
+    expect(getByTestId('focus-rhythm-option-evening').props.accessibilityState.checked).toBe(true);
+  });
+
+  it('toggles a selection off when tapped again', () => {
+    const { getByTestId } = render(<FocusRhythmsScreen />);
+    const opt = () => getByTestId('focus-rhythm-option-afternoon');
+    fireEvent.press(opt());
+    expect(opt().props.accessibilityState.checked).toBe(true);
+    fireEvent.press(opt());
+    expect(opt().props.accessibilityState.checked).toBe(false);
+  });
+
+  it('Save persists the selected windows and returns', async () => {
+    const { getByTestId, getByText } = render(<FocusRhythmsScreen />);
+    fireEvent.press(getByTestId('focus-rhythm-option-mid_morning'));
+    fireEvent.press(getByText('Save'));
+    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('u1', ['mid_morning']));
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('pre-selects the user\'s previously saved windows', async () => {
+    mockGet.mockResolvedValue(['evening']);
+    const { getByTestId } = render(<FocusRhythmsScreen />);
+    await waitFor(() =>
+      expect(getByTestId('focus-rhythm-option-evening').props.accessibilityState.checked).toBe(true)
+    );
+  });
+});

--- a/mobile/src/screens/Focus/__tests__/FocusScreen.test.tsx
+++ b/mobile/src/screens/Focus/__tests__/FocusScreen.test.tsx
@@ -1,9 +1,12 @@
-// Focus-session loop closure (Vara_Engine_Contract.md §12.1).
+// Focus-session loop closure (Vara_Engine_Contract.md §12.1) + the B-3c
+// "Center first" pre-focus box breathing handoff (commit 5).
 //
-// A focus session launched FROM the check-in (route param fromCheckIn) returns
-// to the Focus reflection on "Done for now"; a directly-started one does not.
-// PomodoroTab is mocked to expose its onLoopDone wiring without the timer/audio
-// tree.
+// A focus session launched FROM the check-in (fromCheckIn) OR the hub (fromHub)
+// returns to the Focus reflection on "Done for now". With Center-first ON, the
+// Begin tap first runs box breathing (GuidedSessionPlayer), then hands off to
+// the timer, which still ends on the focus reflection. PomodoroTab and
+// GuidedSessionPlayer are mocked to expose their wiring without the timer/audio
+// trees.
 
 const mockGoBack = jest.fn();
 const mockRoute: {
@@ -30,13 +33,82 @@ jest.mock('../../../utils/logger', () => ({
   logger: { error: jest.fn(), warn: jest.fn(), log: jest.fn() },
 }));
 
-// Mock PomodoroTab — expose whether it received onLoopDone, and a button that
-// fires it (simulating the "Done for now" terminal after a completed block).
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { uid: 'u1' } }),
+}));
+
+const mockGetPrefs = jest.fn((..._a: any[]) => Promise.resolve({ centerFirst: false }));
+const mockSavePrefs = jest.fn((..._a: any[]) => Promise.resolve());
+jest.mock('../../../services/firebase/focusPreferences.service', () => ({
+  getFocusPreferences: (...a: any[]) => mockGetPrefs(...a),
+  saveFocusPreferences: (...a: any[]) => mockSavePrefs(...a),
+}));
+
+const mockWriteSession = jest.fn((..._a: any[]) => Promise.resolve());
+jest.mock('../../../services/firebase/protocolSession.service', () => ({
+  writeProtocolSession: (...a: any[]) => mockWriteSession(...a),
+}));
+
+// Mock GuidedSessionPlayer — expose the protocol it ran and buttons to fire
+// onExit (natural completion / mid-practice abandon).
+jest.mock('../../../components/protocol/GuidedSessionPlayer', () => {
+  const ReactLib = jest.requireActual('react');
+  const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
+  return {
+    GuidedSessionPlayer: (props: any) =>
+      ReactLib.createElement(
+        View,
+        { testID: 'mock-gsp' },
+        ReactLib.createElement(Text, { testID: 'mock-gsp-protocol' }, props.protocol?.id),
+        ReactLib.createElement(
+          TouchableOpacity,
+          {
+            testID: 'mock-gsp-complete',
+            onPress: () =>
+              props.onExit?.({
+                protocolId: props.protocol?.id,
+                stateBefore: null,
+                completed: true,
+                durationActualSeconds: 128,
+                stepsCompleted: 1,
+                totalSteps: 1,
+                abandonReason: null,
+                startedAt: 1000,
+                endedAt: 1128,
+              }),
+          },
+          ReactLib.createElement(Text, null, 'complete')
+        ),
+        ReactLib.createElement(
+          TouchableOpacity,
+          {
+            testID: 'mock-gsp-abandon',
+            onPress: () =>
+              props.onExit?.({
+                protocolId: props.protocol?.id,
+                stateBefore: null,
+                completed: false,
+                durationActualSeconds: 40,
+                stepsCompleted: 0,
+                totalSteps: 1,
+                abandonReason: 'user_exit',
+                startedAt: 1000,
+                endedAt: 1040,
+              }),
+          },
+          ReactLib.createElement(Text, null, 'abandon')
+        )
+      ),
+  };
+});
+
+// Mock PomodoroTab — expose onLoopDone wiring, centerFirst/autoStart props, and
+// buttons to fire onLoopDone, onCenterFirstBegin, onToggleCenterFirst.
 jest.mock('../PomodoroTab', () => {
   const ReactLib = jest.requireActual('react');
   const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
   return {
-    PomodoroTab: (props: { onLoopDone?: (id: string | null) => void }) =>
+    PomodoroTab: (props: any) =>
       ReactLib.createElement(
         View,
         { testID: 'mock-pomodoro' },
@@ -46,19 +118,41 @@ jest.mock('../PomodoroTab', () => {
           props.onLoopDone ? 'loop' : 'direct'
         ),
         ReactLib.createElement(
+          Text,
+          { testID: 'mock-pomodoro-centerfirst' },
+          props.centerFirst ? 'on' : 'off'
+        ),
+        ReactLib.createElement(
+          Text,
+          { testID: 'mock-pomodoro-autostart' },
+          props.autoStart ? 'on' : 'off'
+        ),
+        ReactLib.createElement(
+          Text,
+          { testID: 'mock-pomodoro-cancenter' },
+          props.onCenterFirstBegin ? 'yes' : 'no'
+        ),
+        ReactLib.createElement(
           TouchableOpacity,
-          {
-            testID: 'mock-pomodoro-done',
-            onPress: () => props.onLoopDone?.('focus-doc-1'),
-          },
+          { testID: 'mock-pomodoro-done', onPress: () => props.onLoopDone?.('focus-doc-1') },
           ReactLib.createElement(Text, null, 'done')
+        ),
+        ReactLib.createElement(
+          TouchableOpacity,
+          { testID: 'mock-pomodoro-begin-center', onPress: () => props.onCenterFirstBegin?.(25) },
+          ReactLib.createElement(Text, null, 'begin-center')
+        ),
+        ReactLib.createElement(
+          TouchableOpacity,
+          { testID: 'mock-pomodoro-toggle', onPress: () => props.onToggleCenterFirst?.(true) },
+          ReactLib.createElement(Text, null, 'toggle')
         )
       ),
   };
 });
 
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { FocusScreen } from '../FocusScreen';
 
 beforeEach(() => {
@@ -66,6 +160,10 @@ beforeEach(() => {
   mockUpdateDoc.mockClear();
   mockDoc.mockClear();
   mockRoute.params = undefined;
+  mockGetPrefs.mockReset();
+  mockGetPrefs.mockResolvedValue({ centerFirst: false });
+  mockSavePrefs.mockClear();
+  mockWriteSession.mockClear();
 });
 
 describe('FocusScreen — focus-session loop closure', () => {
@@ -73,11 +171,9 @@ describe('FocusScreen — focus-session loop closure', () => {
     mockRoute.params = { fromCheckIn: true };
     const { getByTestId, queryByTestId } = render(<FocusScreen />);
 
-    // PomodoroTab was given onLoopDone (loop mode); no reflection yet.
     expect(getByTestId('mock-pomodoro-mode').props.children).toBe('loop');
     expect(queryByTestId('checkin-flow-reflection')).toBeNull();
 
-    // "Done for now" → the Focus reflection, with the §9 focus chips.
     fireEvent.press(getByTestId('mock-pomodoro-done'));
     expect(getByTestId('checkin-flow-reflection')).toBeTruthy();
     expect(getByTestId('checkin-flow-reflection-chip-settled')).toBeTruthy();
@@ -97,7 +193,6 @@ describe('FocusScreen — focus-session loop closure', () => {
     expect(mockUpdateDoc.mock.calls[0][1]).toEqual(
       expect.objectContaining({ reflection: 'settled' })
     );
-    // Exit home — same exit a catalog-practice reflection uses.
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 
@@ -105,7 +200,6 @@ describe('FocusScreen — focus-session loop closure', () => {
     mockRoute.params = { fromHub: true };
     const { getByTestId, queryByTestId } = render(<FocusScreen />);
 
-    // Hub launch also drives the loop (onLoopDone present); no reflection yet.
     expect(getByTestId('mock-pomodoro-mode').props.children).toBe('loop');
     expect(queryByTestId('checkin-flow-reflection')).toBeNull();
 
@@ -135,5 +229,93 @@ describe('FocusScreen — focus-session loop closure', () => {
     fireEvent.press(getByTestId('mock-pomodoro-done')); // onLoopDone is undefined → no-op
     expect(queryByTestId('checkin-flow-reflection')).toBeNull();
     expect(mockGoBack).not.toHaveBeenCalled();
+  });
+});
+
+describe('FocusScreen — Center first (B-3c commit 5)', () => {
+  it('initializes the Center-first row from the persisted preference', async () => {
+    mockGetPrefs.mockResolvedValue({ centerFirst: true });
+    mockRoute.params = { fromHub: true };
+    const { getByTestId } = render(<FocusScreen />);
+    await waitFor(() =>
+      expect(getByTestId('mock-pomodoro-centerfirst').props.children).toBe('on')
+    );
+    expect(mockGetPrefs).toHaveBeenCalledWith('u1');
+  });
+
+  it('persists the choice when the row is toggled', async () => {
+    mockRoute.params = { fromHub: true };
+    const { getByTestId } = render(<FocusScreen />);
+    fireEvent.press(getByTestId('mock-pomodoro-toggle'));
+    await waitFor(() =>
+      expect(mockSavePrefs).toHaveBeenCalledWith('u1', { centerFirst: true })
+    );
+    expect(getByTestId('mock-pomodoro-centerfirst').props.children).toBe('on');
+  });
+
+  it('ON: Begin launches box breathing, then hands off to the auto-started timer', async () => {
+    mockGetPrefs.mockResolvedValue({ centerFirst: true });
+    mockRoute.params = { fromHub: true };
+    const { getByTestId, queryByTestId } = render(<FocusScreen />);
+    await waitFor(() =>
+      expect(getByTestId('mock-pomodoro-centerfirst').props.children).toBe('on')
+    );
+
+    // Begin with centering → box breathing runs (the fixed 2-min protocol).
+    fireEvent.press(getByTestId('mock-pomodoro-begin-center'));
+    expect(getByTestId('mock-gsp')).toBeTruthy();
+    expect(getByTestId('mock-gsp-protocol').props.children).toBe('box-breathing-2');
+    expect(queryByTestId('mock-pomodoro')).toBeNull(); // timer not shown during centering
+
+    // Completion → writes its OWN protocolSession row, then hands off to the
+    // auto-started timer.
+    fireEvent.press(getByTestId('mock-gsp-complete'));
+    expect(mockWriteSession).toHaveBeenCalledTimes(1);
+    expect(mockWriteSession.mock.calls[0][0]).toBe('u1');
+    expect(mockWriteSession.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        protocolId: 'box-breathing-2',
+        stateBefore: null,
+        stateAfter: null,
+        outcome: 'browse_launched',
+      })
+    );
+    expect(getByTestId('mock-pomodoro')).toBeTruthy();
+    expect(getByTestId('mock-pomodoro-autostart').props.children).toBe('on');
+    // Centering consumed: a second block starts directly (no re-center).
+    expect(getByTestId('mock-pomodoro-cancenter').props.children).toBe('no');
+  });
+
+  it('ON: the single end-of-loop reflection is still the FOCUS reflection', async () => {
+    mockGetPrefs.mockResolvedValue({ centerFirst: true });
+    mockRoute.params = { fromHub: true };
+    const { getByTestId } = render(<FocusScreen />);
+    await waitFor(() =>
+      expect(getByTestId('mock-pomodoro-centerfirst').props.children).toBe('on')
+    );
+
+    fireEvent.press(getByTestId('mock-pomodoro-begin-center'));
+    fireEvent.press(getByTestId('mock-gsp-complete')); // box breathing done → timer
+    // Timer "Done for now" → the FOCUS reflection (not a box-breathing one).
+    fireEvent.press(getByTestId('mock-pomodoro-done'));
+    expect(getByTestId('checkin-flow-reflection')).toBeTruthy();
+    expect(getByTestId('checkin-flow-reflection-chip-settled')).toBeTruthy();
+  });
+
+  it('ON but abandoned mid-practice: writes an abandoned row and returns to the timer un-started', async () => {
+    mockGetPrefs.mockResolvedValue({ centerFirst: true });
+    mockRoute.params = { fromHub: true };
+    const { getByTestId } = render(<FocusScreen />);
+    await waitFor(() =>
+      expect(getByTestId('mock-pomodoro-centerfirst').props.children).toBe('on')
+    );
+
+    fireEvent.press(getByTestId('mock-pomodoro-begin-center'));
+    fireEvent.press(getByTestId('mock-gsp-abandon'));
+    expect(mockWriteSession.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ protocolId: 'box-breathing-2', outcome: 'abandoned' })
+    );
+    expect(getByTestId('mock-pomodoro')).toBeTruthy();
+    expect(getByTestId('mock-pomodoro-autostart').props.children).toBe('off');
   });
 });

--- a/mobile/src/screens/Focus/__tests__/FocusScreen.test.tsx
+++ b/mobile/src/screens/Focus/__tests__/FocusScreen.test.tsx
@@ -6,7 +6,9 @@
 // tree.
 
 const mockGoBack = jest.fn();
-const mockRoute: { params: { fromCheckIn?: boolean } | undefined } = {
+const mockRoute: {
+  params: { fromCheckIn?: boolean; fromHub?: boolean } | undefined;
+} = {
   params: undefined,
 };
 
@@ -96,6 +98,32 @@ describe('FocusScreen — focus-session loop closure', () => {
       expect.objectContaining({ reflection: 'settled' })
     );
     // Exit home — same exit a catalog-practice reflection uses.
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('hub-launched: "Done for now" chains into the Focus reflection', () => {
+    mockRoute.params = { fromHub: true };
+    const { getByTestId, queryByTestId } = render(<FocusScreen />);
+
+    // Hub launch also drives the loop (onLoopDone present); no reflection yet.
+    expect(getByTestId('mock-pomodoro-mode').props.children).toBe('loop');
+    expect(queryByTestId('checkin-flow-reflection')).toBeNull();
+
+    fireEvent.press(getByTestId('mock-pomodoro-done'));
+    expect(getByTestId('checkin-flow-reflection')).toBeTruthy();
+    expect(getByTestId('checkin-flow-reflection-chip-settled')).toBeTruthy();
+  });
+
+  it('hub-launched: selecting a reflection writes it (focus vocabulary) and exits', () => {
+    mockRoute.params = { fromHub: true };
+    const { getByTestId } = render(<FocusScreen />);
+    fireEvent.press(getByTestId('mock-pomodoro-done'));
+    fireEvent.press(getByTestId('checkin-flow-reflection-chip-settled'));
+
+    expect(mockDoc).toHaveBeenCalledWith(expect.anything(), 'focusSessions', 'focus-doc-1');
+    expect(mockUpdateDoc.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ reflection: 'settled' })
+    );
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 

--- a/mobile/src/screens/Focus/__tests__/centerFirst.test.ts
+++ b/mobile/src/screens/Focus/__tests__/centerFirst.test.ts
@@ -1,0 +1,33 @@
+import { resolvePlayAction } from '../centerFirst';
+
+describe('resolvePlayAction — what the timer Begin/play tap should do', () => {
+  it('idle + Center-first ON + centering available -> center', () => {
+    expect(
+      resolvePlayAction('idle', { centerFirst: true, canCenter: true })
+    ).toBe('center');
+  });
+
+  it('idle + Center-first OFF -> start the timer directly', () => {
+    expect(
+      resolvePlayAction('idle', { centerFirst: false, canCenter: true })
+    ).toBe('start');
+  });
+
+  it('idle + Center-first ON but already centered (no centering available) -> start', () => {
+    expect(
+      resolvePlayAction('idle', { centerFirst: true, canCenter: false })
+    ).toBe('start');
+  });
+
+  it('running -> pause', () => {
+    expect(resolvePlayAction('running', { centerFirst: true, canCenter: true })).toBe('pause');
+  });
+
+  it('break_running -> pause', () => {
+    expect(resolvePlayAction('break_running', { centerFirst: false, canCenter: false })).toBe('pause');
+  });
+
+  it('paused -> resume', () => {
+    expect(resolvePlayAction('paused', { centerFirst: true, canCenter: true })).toBe('resume');
+  });
+});

--- a/mobile/src/screens/Focus/centerFirst.ts
+++ b/mobile/src/screens/Focus/centerFirst.ts
@@ -1,0 +1,36 @@
+// Pure decision helper for the Focus timer's Begin/play tap (B-3c commit 5).
+//
+// The timer setup has an opt-in "Center first" row. When it is ON and a
+// centering practice is still available for this session, the first Begin tap
+// should launch the pre-focus box breathing practice rather than starting the
+// timer. Extracted as a pure function so the ON (center) vs OFF (start directly)
+// decision is unit-testable without mounting the timer.
+
+export type TimerPlayState =
+  | 'idle'
+  | 'running'
+  | 'break_running'
+  | 'paused'
+  | string;
+
+export type PlayAction = 'center' | 'start' | 'pause' | 'resume' | 'noop';
+
+export interface PlayActionInput {
+  // The user's persisted "Center first" choice, controlling the setup row.
+  centerFirst: boolean;
+  // Whether a centering practice is still launchable this session (false once
+  // the user has already centered, so a second block starts directly).
+  canCenter: boolean;
+}
+
+export function resolvePlayAction(
+  state: TimerPlayState,
+  { centerFirst, canCenter }: PlayActionInput
+): PlayAction {
+  if (state === 'idle') {
+    return centerFirst && canCenter ? 'center' : 'start';
+  }
+  if (state === 'running' || state === 'break_running') return 'pause';
+  if (state === 'paused') return 'resume';
+  return 'noop';
+}

--- a/mobile/src/screens/Focus/components/CenterFirstToggle.tsx
+++ b/mobile/src/screens/Focus/components/CenterFirstToggle.tsx
@@ -1,0 +1,111 @@
+/**
+ * CenterFirstToggle (B-3c commit 5)
+ * Opt-in row on the focus timer setup. When on, a short box breathing practice
+ * runs before the focus session to help the user arrive at the task. Remembered
+ * across sessions (the value is persisted by the parent). Silver Sage off, Teal
+ * on, mirroring NotificationToggle.
+ *
+ * Copy is about arriving at the task, not winding down — deliberately calm and
+ * non-clinical, no performance framing.
+ */
+
+import React from 'react';
+import { View, StyleSheet, Switch, TouchableOpacity, Text } from 'react-native';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import {
+  ColorTokens,
+  SpacingTokens,
+  RadiusTokens,
+  ShadowTokens,
+} from '../../../constants/designTokens';
+
+const HEADING = 'Center first';
+const BODY = 'A short box breathing practice to settle in before you focus.';
+
+interface CenterFirstToggleProps {
+  value: boolean;
+  onToggle: (next: boolean) => void;
+}
+
+export const CenterFirstToggle: React.FC<CenterFirstToggleProps> = ({
+  value,
+  onToggle,
+}) => {
+  const handleToggle = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onToggle(!value);
+  };
+
+  return (
+    <TouchableOpacity
+      style={styles.container}
+      onPress={handleToggle}
+      activeOpacity={0.8}
+      accessibilityRole="switch"
+      accessibilityState={{ checked: value }}
+      accessibilityLabel={`${HEADING}, ${value ? 'on' : 'off'}`}
+      testID="center-first-toggle"
+    >
+      <View style={styles.leftContent}>
+        <Icon
+          name="weather-windy"
+          size={20}
+          color={value ? ColorTokens.primary : ColorTokens.textSecondary}
+        />
+        <View style={styles.textContainer}>
+          <Text style={styles.label}>{HEADING}</Text>
+          <Text style={styles.helper}>{BODY}</Text>
+        </View>
+      </View>
+
+      <Switch
+        value={value}
+        onValueChange={handleToggle}
+        trackColor={{ false: ColorTokens.secondary, true: ColorTokens.primary }}
+        thumbColor={ColorTokens.backgroundSurface}
+        ios_backgroundColor={ColorTokens.secondary}
+        style={styles.switch}
+      />
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: ColorTokens.backgroundSurface,
+    borderRadius: RadiusTokens.lg,
+    paddingVertical: 14,
+    paddingHorizontal: SpacingTokens.base,
+    marginBottom: SpacingTokens.base,
+    ...ShadowTokens.sm,
+  },
+  leftContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  textContainer: {
+    marginLeft: SpacingTokens.md,
+    flex: 1,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: ColorTokens.textPrimary,
+  },
+  helper: {
+    fontSize: 12,
+    fontWeight: '400',
+    color: ColorTokens.textSecondary,
+    marginTop: 2,
+  },
+  switch: {
+    transform: [{ scaleX: 0.9 }, { scaleY: 0.9 }],
+  },
+});
+
+export default CenterFirstToggle;

--- a/mobile/src/screens/Focus/index.ts
+++ b/mobile/src/screens/Focus/index.ts
@@ -4,6 +4,7 @@
 
 export { FocusScreen } from './FocusScreen';
 export { FocusHubScreen } from './FocusHubScreen';
+export { FocusRhythmsScreen } from './FocusRhythmsScreen';
 export { PomodoroTab } from './PomodoroTab';
 
 // Re-export Pomodoro components for use elsewhere

--- a/mobile/src/screens/Focus/index.ts
+++ b/mobile/src/screens/Focus/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { FocusScreen } from './FocusScreen';
+export { FocusHubScreen } from './FocusHubScreen';
 export { PomodoroTab } from './PomodoroTab';
 
 // Re-export Pomodoro components for use elsewhere

--- a/mobile/src/services/firebase/__tests__/focusPreferences.service.test.ts
+++ b/mobile/src/services/firebase/__tests__/focusPreferences.service.test.ts
@@ -1,0 +1,54 @@
+const mockUpdateDoc = jest.fn((..._a: any[]) => Promise.resolve(undefined));
+const mockDoc = jest.fn((..._a: any[]) => ({ __ref: true }));
+const mockServerTimestamp = jest.fn(() => '__ts__');
+const mockGetDoc = jest.fn((..._a: any[]): any => undefined);
+
+jest.mock('firebase/firestore', () => ({
+  doc: (...a: any[]) => mockDoc(...a),
+  getDoc: (...a: any[]) => mockGetDoc(...a),
+  updateDoc: (...a: any[]) => mockUpdateDoc(...a),
+  serverTimestamp: () => mockServerTimestamp(),
+}));
+jest.mock('../../../config/firebase', () => ({ db: { __db: true } }));
+
+import {
+  saveFocusPreferences,
+  getFocusPreferences,
+} from '../focusPreferences.service';
+
+describe('focusPreferences.service', () => {
+  beforeEach(() => {
+    mockUpdateDoc.mockClear();
+    mockGetDoc.mockReset();
+    mockDoc.mockClear();
+  });
+
+  test('saveFocusPreferences persists centerFirst on users/{uid} + updatedAt', async () => {
+    await saveFocusPreferences('u1', { centerFirst: true });
+    expect(mockDoc).toHaveBeenCalledWith({ __db: true }, 'users', 'u1');
+    expect(mockUpdateDoc.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        'focusPreferences.centerFirst': true,
+        'focusPreferences.updatedAt': '__ts__',
+      })
+    );
+  });
+
+  test('getFocusPreferences returns the stored centerFirst', async () => {
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ focusPreferences: { centerFirst: true } }),
+    });
+    expect(await getFocusPreferences('u1')).toEqual({ centerFirst: true });
+  });
+
+  test('getFocusPreferences defaults centerFirst to false when absent', async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => true, data: () => ({}) });
+    expect(await getFocusPreferences('u1')).toEqual({ centerFirst: false });
+  });
+
+  test('getFocusPreferences defaults to false when the user doc does not exist', async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false });
+    expect(await getFocusPreferences('u1')).toEqual({ centerFirst: false });
+  });
+});

--- a/mobile/src/services/firebase/__tests__/focusRhythms.service.test.ts
+++ b/mobile/src/services/firebase/__tests__/focusRhythms.service.test.ts
@@ -1,0 +1,59 @@
+const mockUpdateDoc = jest.fn((..._a: any[]) => Promise.resolve(undefined));
+const mockDoc = jest.fn((..._a: any[]) => ({ __ref: true }));
+const mockServerTimestamp = jest.fn(() => '__ts__');
+const mockGetDoc = jest.fn((..._a: any[]): any => undefined);
+
+jest.mock('firebase/firestore', () => ({
+  doc: (...a: any[]) => mockDoc(...a),
+  getDoc: (...a: any[]) => mockGetDoc(...a),
+  updateDoc: (...a: any[]) => mockUpdateDoc(...a),
+  serverTimestamp: () => mockServerTimestamp(),
+}));
+jest.mock('../../../config/firebase', () => ({ db: { __db: true } }));
+
+import { saveFocusRhythms, getFocusRhythms } from '../focusRhythms.service';
+
+describe('focusRhythms.service', () => {
+  beforeEach(() => {
+    mockUpdateDoc.mockClear();
+    mockGetDoc.mockReset();
+    mockDoc.mockClear();
+  });
+
+  test('saveFocusRhythms persists the windows array on users/{uid} + updatedAt, no scores', async () => {
+    await saveFocusRhythms('u1', ['early_morning', 'evening']);
+    expect(mockDoc).toHaveBeenCalledWith({ __db: true }, 'users', 'u1');
+    const patch = mockUpdateDoc.mock.calls[0][1];
+    expect(patch).toEqual(
+      expect.objectContaining({
+        'focusRhythms.windows': ['early_morning', 'evening'],
+        'focusRhythms.updatedAt': '__ts__',
+      })
+    );
+    // Capture only — no score / count fields ever written.
+    expect(JSON.stringify(patch)).not.toMatch(/score|count|streak/i);
+  });
+
+  test('saveFocusRhythms accepts an empty selection', async () => {
+    await saveFocusRhythms('u1', []);
+    expect(mockUpdateDoc.mock.calls[0][1]['focusRhythms.windows']).toEqual([]);
+  });
+
+  test('getFocusRhythms returns the stored windows', async () => {
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ focusRhythms: { windows: ['afternoon'] } }),
+    });
+    expect(await getFocusRhythms('u1')).toEqual(['afternoon']);
+  });
+
+  test('getFocusRhythms returns [] when the field is absent', async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => true, data: () => ({}) });
+    expect(await getFocusRhythms('u1')).toEqual([]);
+  });
+
+  test('getFocusRhythms returns [] when the user doc does not exist', async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false });
+    expect(await getFocusRhythms('u1')).toEqual([]);
+  });
+});

--- a/mobile/src/services/firebase/focusPreferences.service.ts
+++ b/mobile/src/services/firebase/focusPreferences.service.ts
@@ -1,0 +1,44 @@
+/**
+ * Persists the user's Focus preferences (Four-Pillar IA Phase B-3c) on
+ * users/{uid}. Follows the focusRhythms.service / onboardingStressRecovery
+ * pattern (updateDoc + serverTimestamp on the user doc, nested dot-path fields).
+ *
+ * Currently just the "Center first" choice (whether to run a short box
+ * breathing practice before a focus session). Remembered across sessions, not
+ * reset each time. No new collection.
+ */
+import { doc, getDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from '../../config/firebase';
+
+const USERS_COLLECTION = 'users';
+
+export interface FocusPreferences {
+  centerFirst: boolean;
+}
+
+const DEFAULTS: FocusPreferences = { centerFirst: false };
+
+function userRef(userId: string) {
+  if (!db) throw new Error('Firestore not initialized');
+  return doc(db, USERS_COLLECTION, userId);
+}
+
+export async function saveFocusPreferences(
+  userId: string,
+  prefs: FocusPreferences
+): Promise<void> {
+  await updateDoc(userRef(userId), {
+    'focusPreferences.centerFirst': prefs.centerFirst,
+    'focusPreferences.updatedAt': serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
+}
+
+export async function getFocusPreferences(
+  userId: string
+): Promise<FocusPreferences> {
+  const snap = await getDoc(userRef(userId));
+  if (!snap.exists()) return { ...DEFAULTS };
+  const centerFirst = snap.data()?.focusPreferences?.centerFirst;
+  return { centerFirst: centerFirst === true };
+}

--- a/mobile/src/services/firebase/focusRhythms.service.ts
+++ b/mobile/src/services/firebase/focusRhythms.service.ts
@@ -1,0 +1,36 @@
+/**
+ * Persists the user's focus rhythms (Four-Pillar IA Phase B-3c) on
+ * users/{uid}. Follows the onboardingStressRecovery.service.ts pattern
+ * (updateDoc + serverTimestamp on the user doc, nested dot-path fields).
+ *
+ * This is a plain user-level capture: an array of time-of-day keys plus an
+ * updatedAt. No scores, no counts, no session/protocol rows. Downstream use is
+ * out of scope for this slice.
+ */
+import { doc, getDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from '../../config/firebase';
+
+const USERS_COLLECTION = 'users';
+
+function userRef(userId: string) {
+  if (!db) throw new Error('Firestore not initialized');
+  return doc(db, USERS_COLLECTION, userId);
+}
+
+export async function saveFocusRhythms(
+  userId: string,
+  windows: string[]
+): Promise<void> {
+  await updateDoc(userRef(userId), {
+    'focusRhythms.windows': windows,
+    'focusRhythms.updatedAt': serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
+}
+
+export async function getFocusRhythms(userId: string): Promise<string[]> {
+  const snap = await getDoc(userRef(userId));
+  if (!snap.exists()) return [];
+  const windows = snap.data()?.focusRhythms?.windows;
+  return Array.isArray(windows) ? windows : [];
+}


### PR DESCRIPTION
## B-3c — Focus hub

Builds the Focus pillar hub on `main`. Five of six planned commits landed; **commit 5 (settle-first handoff) was STOPPED at its explicit gates** (details below) — the hub ships fully functional without it.

### Commits (in order, each green & bisectable)
1. `c157317` reword focus reflection chips → "Stayed with it / Drifted some / Kept slipping" (ids `settled/some/still_busy` and strong-positive marker unchanged)
2. `f980802` FocusHubScreen as the PillarFocus tab root (FocusScreen stays the FocusTimer stack screen); Focus tab `showFAB` stays true
3. `cd16e95` hub-launched timer chains into the focus reflection via explicit `fromHub` param (check-in behavior untouched)
4. `66d505d` FocusRhythmsScreen + `focusRhythms.service` (multi-select, persisted as a plain key array on `users/{uid}`)
5. **STOPPED** — settle-first handoff (see below)
6. `65e5cc5` extend brandCopyGuard to the new Focus screens + reflection copy

### STOP-gate report
- **FOCUS_SET had no other consumer relying on the old labels.** `outcomeClassifier` reads ids only (`chips[2].id`); `reflectionDisplayChips` reads ids (labels come from `CATEGORY_LABELS`). `settle_before_focus` is a separate set, untouched.
- **User-settings location for rhythms:** `users/{uid}` doc (`focusRhythms.windows` + `updatedAt`), following the `onboardingStressRecovery.service` pattern. No new collection, no scores/counts.
- **Commit 5 STOPPED — three convergent gate trips:**
  1. *No single identifiable settle practice.* The check-in "settle before focus" lead is plan-resolved per quadrant (`planMap.ts`: settle-breath for Tense, grounding for Calm / quiet_mind-Activated, **energize** for Depleted — not even a regulate practice), then ranked dynamically to one of several eligible Protocols by the full BrainState/budget. There is no fixed protocol to reuse.
  2. *No hub BrainState without fabrication.* The hub has no check-in/current state; producing the "real BrainState" the settle reset requires would mean synthesizing one. Null-over-fabrication forbids it.
  3. *Completion redirect can't avoid the shared path.* The settle practice runs via `PracticeRunScreen.handleComplete`, the shared terminal handler for both browse picks and check-in continuations (branches on `fromCheckInFlow`/`stateBefore`/`intentPath`). Redirecting it onward to the timer means modifying that shared path — the explicit STOP gate.

  → Reported for scoping. A half-built OFF-only "Settle first" row was deliberately NOT shipped (a placebo toggle violates "offered, never forced").

### Integrity confirmations
- **No `protocolId`/`BrainState` fabricated anywhere.** `focusSessions` stayed the timer-session target; the focus reflection's `stateBefore`/`stateAfter` are never synthesized (null/absent).
- **Energy screens / `showFAB` untouched** (Energy stays `showFAB:false`; Focus stays `showFAB:true`).
- All new routes registered in the typed registry (`FocusRhythms`); no dead nav targets.
- **tsc on branch: 167** (unchanged baseline).
- **Tests: 1240 passing** (baseline 1214, +26); sole failing suite is `AuthContext.test.tsx` (known ESM-load issue).

### Device-walk entry points (FOUR_PILLAR_IA on)
- **Focus tab** → FocusHubScreen (title "Focus", primary "Set a focus" card, secondary "Focus rhythms").
- Primary card → FocusTimer (`fromHub:true`) → complete a block → "Done for now" → focus reflection ("Stayed with it / Drifted some / Kept slipping") → exits.
- Secondary card → FocusRhythms (multi-select, Save persists to `users/{uid}.focusRhythms.windows`, re-entry pre-selects).
- Regression to confirm untouched: check-in focus-session loop still ends on the focus reflection; Energy tab/hub/browse unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)