### PR TITLE
B-3c.2: focus timer survives screen-sleep + completion-notification deep-link

### DIFF
--- a/mobile/src/constants/focusContent.ts
+++ b/mobile/src/constants/focusContent.ts
@@ -85,6 +85,12 @@ export const FocusCopy = {
   completeCtaPrimary: 'Done',
   completeCtaSecondary: 'Adjust this routine',
 
+  // Focus completion notification (B-3c.2). Fires when a focus block's time
+  // elapses while the app is backgrounded or closed. Calm and outcome-neutral:
+  // no urgency, no "time's up", no deficit framing.
+  focusCompleteNotificationTitle: 'Your focus block is complete',
+  focusCompleteNotificationBody: 'Come back when you\'re ready.',
+
   // Notifications
   morningReminder: 'Your morning routine is ready whenever you are.',
   eveningReminder: 'A quiet moment for your evening routine, if it feels right.',

--- a/mobile/src/context/NotificationContext.tsx
+++ b/mobile/src/context/NotificationContext.tsx
@@ -19,7 +19,15 @@ import {
   registerAndSaveFCMToken,
   isServerPushEnabled,
   addNotificationResponseListener,
+  getLastNotificationResponse,
 } from '../services/notifications.service';
+import {
+  getActiveFocusSession,
+  clearActiveFocusSession,
+  finalizeFocusSession,
+  planFocusCompleteLaunch,
+} from '../services/firebase/focusSession.service';
+import { logger } from '../utils/logger';
 import { syncAllReminders } from '../services/reminderScheduler.service';
 import { isHabitCompletedToday } from '../services/firebase/habits.service';
 import { navigationRef } from '../navigation/AppNavigator';
@@ -46,6 +54,23 @@ interface NotificationContextType {
 }
 
 const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
+
+/** Resolve once the navigation container is ready (bounded), for cold-launch routing. */
+async function waitForNavReady(timeoutMs = 5000): Promise<boolean> {
+  const start = Date.now();
+  while (!navigationRef.isReady()) {
+    if (Date.now() - start > timeoutMs) return false;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return true;
+}
+
+/** Navigate to the focus timer, optionally bound to a completed block's id. */
+function navigateToFocusTimer(completedSessionId?: string): void {
+  if (!navigationRef.isReady()) return;
+  const navigate = navigationRef.navigate as (name: string, params?: object) => void;
+  navigate(ROUTES.FocusTimer, completedSessionId ? { completedSessionId } : undefined);
+}
 
 export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user } = useAuth();
@@ -132,11 +157,58 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
         // Routines live on the Rhythms tab (the focus-timer route is `FocusTimer`,
         // not `Focus`; the old `Focus` target was dead).
         navigationRef.navigate(ROUTES.Rhythms as never, { tab: 'routines' } as never);
+      } else if (data.type === 'focus-complete') {
+        // Warm/background tap: the block's row was finalized by the live
+        // foreground reconcile; land the completion surface bound to it so the
+        // inline reflection can write.
+        const id = typeof data.focusSessionId === 'string' ? data.focusSessionId : undefined;
+        navigateToFocusTimer(id);
       }
     });
 
     return () => subscription.remove();
   }, []);
+
+  // Cold-launch deep link: the app was opened by TAPPING a focus-complete
+  // notification while killed, so the warm response listener above never saw the
+  // tap. Read the launch response, finalize the elapsed block from its persisted
+  // record (stable id), and route to the completion surface bound to it. A
+  // missing / not-yet-elapsed / other-user record degrades to opening Focus
+  // plain (no fabricated completion, no crash).
+  useEffect(() => {
+    if (!user?.uid) return;
+    const uid = user.uid;
+    let cancelled = false;
+    (async () => {
+      const response = await getLastNotificationResponse();
+      if (cancelled || !response) return;
+      const data = response.notification.request.content.data;
+      if (data?.type !== 'focus-complete') return;
+
+      const record = await getActiveFocusSession();
+      const plan = planFocusCompleteLaunch(record, uid, Date.now());
+      if (plan.finalize) {
+        try {
+          await finalizeFocusSession({
+            focusSessionId: plan.finalize.focusSessionId,
+            userId: plan.finalize.userId,
+            durationMinutes: plan.finalize.durationMinutes,
+            type: plan.finalize.type,
+            taskLabel: plan.finalize.taskLabel,
+          });
+        } catch (error) {
+          logger.error('[NotificationContext] cold-launch finalize failed', error);
+        }
+        await clearActiveFocusSession();
+      }
+      if (cancelled) return;
+      if (!(await waitForNavReady())) return;
+      navigateToFocusTimer(plan.completedSessionId ?? undefined);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.uid]);
 
   // Cancel all notifications when user logs out
   useEffect(() => {

--- a/mobile/src/hooks/__tests__/useActiveFocusSession.test.ts
+++ b/mobile/src/hooks/__tests__/useActiveFocusSession.test.ts
@@ -1,0 +1,166 @@
+/**
+ * useActiveFocusSession — owns the persisted active-session record across a
+ * focus block's lifecycle and finalizes the focusSessions row on completion or
+ * on app return (B-3c.2 commit 2). The focusSession.service is mocked so the
+ * hook's orchestration is tested without AsyncStorage / Firestore.
+ */
+
+const mockMint = jest.fn((): string => 'minted-1');
+const mockSave = jest.fn((_r: unknown) => Promise.resolve());
+const mockGet = jest.fn((): Promise<unknown> => Promise.resolve(null));
+const mockClear = jest.fn(() => Promise.resolve());
+const mockFinalize = jest.fn((_i: unknown) => Promise.resolve());
+
+jest.mock('../../services/firebase/focusSession.service', () => ({
+  mintFocusSessionId: () => mockMint(),
+  saveActiveFocusSession: (r: unknown) => mockSave(r),
+  getActiveFocusSession: () => mockGet(),
+  clearActiveFocusSession: () => mockClear(),
+  finalizeFocusSession: (i: unknown) => mockFinalize(i),
+  isFocusSessionElapsed: (rec: { endsAt: number }, now: number) => rec.endsAt <= now,
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), log: jest.fn() },
+}));
+
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import type { TimerState } from '../useTimer';
+import { useActiveFocusSession } from '../useActiveFocusSession';
+
+interface Props {
+  userId: string | null;
+  timerState: TimerState;
+  endsAt: number | null;
+  durationMinutes: number;
+  taskLabel: string | null;
+}
+
+const base: Props = {
+  userId: 'u1',
+  timerState: 'idle',
+  endsAt: null,
+  durationMinutes: 25,
+  taskLabel: 'Writing',
+};
+
+beforeEach(() => {
+  mockMint.mockClear();
+  mockMint.mockReturnValue('minted-1');
+  mockSave.mockClear();
+  mockGet.mockReset();
+  mockGet.mockResolvedValue(null);
+  mockClear.mockClear();
+  mockFinalize.mockClear();
+});
+
+describe('persist on running', () => {
+  it('mints a stable id once and saves the active record when a focus block runs', () => {
+    const endsAt = Date.now() + 25 * 60_000;
+    renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: { ...base, timerState: 'running', endsAt },
+    });
+    expect(mockMint).toHaveBeenCalledTimes(1);
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(mockSave.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        focusSessionId: 'minted-1',
+        userId: 'u1',
+        durationMinutes: 25,
+        type: 'pomodoro',
+        taskLabel: 'Writing',
+        endsAt,
+      })
+    );
+  });
+
+  it('re-saves with the SAME id when resuming (endsAt changes)', () => {
+    const { rerender } = renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: { ...base, timerState: 'running', endsAt: 1000 },
+    });
+    expect(mockMint).toHaveBeenCalledTimes(1);
+    rerender({ ...base, timerState: 'running', endsAt: 2000 });
+    expect(mockMint).toHaveBeenCalledTimes(1); // not re-minted
+    expect(mockSave).toHaveBeenCalledTimes(2);
+    expect(mockSave.mock.calls[1][0]).toEqual(
+      expect.objectContaining({ focusSessionId: 'minted-1', endsAt: 2000 })
+    );
+  });
+
+  it('clears the persisted record when paused (without losing the id)', () => {
+    const { rerender } = renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: { ...base, timerState: 'running', endsAt: 1000 },
+    });
+    mockClear.mockClear();
+    rerender({ ...base, timerState: 'paused', endsAt: 1000 });
+    expect(mockClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not persist a break (break_running)', () => {
+    renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: { ...base, timerState: 'break_running', endsAt: 1000 },
+    });
+    expect(mockMint).not.toHaveBeenCalled();
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+});
+
+describe('finalizeCompletedBlock', () => {
+  it('finalizes the running block under its stable id and clears the record', async () => {
+    const { result } = renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: { ...base, timerState: 'running', endsAt: 1000 },
+    });
+    let written: string | null = null;
+    await act(async () => {
+      written = await result.current.finalizeCompletedBlock();
+    });
+    expect(written).toBe('minted-1');
+    expect(mockFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({ focusSessionId: 'minted-1', userId: 'u1', type: 'pomodoro' })
+    );
+    expect(mockClear).toHaveBeenCalled();
+    expect(result.current.getLastFocusSessionId()).toBe('minted-1');
+  });
+});
+
+describe('finalize on app return (startup)', () => {
+  it('finalizes a persisted record whose endsAt already passed', async () => {
+    mockGet.mockResolvedValueOnce({
+      focusSessionId: 'fs-old',
+      userId: 'u1',
+      durationMinutes: 25,
+      type: 'pomodoro',
+      taskLabel: null,
+      startedAt: 0,
+      endsAt: Date.now() - 1000,
+    });
+    const { result } = renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: base,
+    });
+    await waitFor(() =>
+      expect(mockFinalize).toHaveBeenCalledWith(
+        expect.objectContaining({ focusSessionId: 'fs-old' })
+      )
+    );
+    expect(mockClear).toHaveBeenCalled();
+    expect(result.current.getLastFocusSessionId()).toBe('fs-old');
+  });
+
+  it('leaves a not-yet-elapsed record alone (no fabricated completion)', async () => {
+    mockGet.mockResolvedValueOnce({
+      focusSessionId: 'fs-future',
+      userId: 'u1',
+      durationMinutes: 25,
+      type: 'pomodoro',
+      taskLabel: null,
+      startedAt: 0,
+      endsAt: Date.now() + 60_000,
+    });
+    renderHook((p: Props) => useActiveFocusSession(p), { initialProps: base });
+    // Give the async effect a tick.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockFinalize).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/hooks/__tests__/useActiveFocusSession.test.ts
+++ b/mobile/src/hooks/__tests__/useActiveFocusSession.test.ts
@@ -20,6 +20,15 @@ jest.mock('../../services/firebase/focusSession.service', () => ({
   isFocusSessionElapsed: (rec: { endsAt: number }, now: number) => rec.endsAt <= now,
 }));
 
+const mockScheduleNotif = jest.fn(
+  (_id: string, _e: number): Promise<string | null> => Promise.resolve('notif-1')
+);
+const mockCancelNotif = jest.fn((_id: string) => Promise.resolve());
+jest.mock('../../services/notifications.service', () => ({
+  scheduleFocusCompletionNotification: (id: string, e: number) => mockScheduleNotif(id, e),
+  cancelScheduledNotification: (id: string) => mockCancelNotif(id),
+}));
+
 jest.mock('../../utils/logger', () => ({
   logger: { error: jest.fn(), warn: jest.fn(), log: jest.fn() },
 }));
@@ -52,6 +61,9 @@ beforeEach(() => {
   mockGet.mockResolvedValue(null);
   mockClear.mockClear();
   mockFinalize.mockClear();
+  mockScheduleNotif.mockClear();
+  mockScheduleNotif.mockResolvedValue('notif-1');
+  mockCancelNotif.mockClear();
 });
 
 describe('persist on running', () => {
@@ -120,6 +132,44 @@ describe('finalizeCompletedBlock', () => {
     );
     expect(mockClear).toHaveBeenCalled();
     expect(result.current.getLastFocusSessionId()).toBe('minted-1');
+  });
+});
+
+describe('completion notification', () => {
+  it('schedules the completion notification when a focus block runs', async () => {
+    renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: { ...base, timerState: 'running', endsAt: 5000 },
+    });
+    await waitFor(() =>
+      expect(mockScheduleNotif).toHaveBeenCalledWith('minted-1', 5000)
+    );
+  });
+
+  it('does not schedule a notification for a break', () => {
+    renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: { ...base, timerState: 'break_running', endsAt: 5000 },
+    });
+    expect(mockScheduleNotif).not.toHaveBeenCalled();
+  });
+
+  it('cancels the scheduled notification when paused', async () => {
+    const { rerender } = renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: { ...base, timerState: 'running', endsAt: 5000 },
+    });
+    await waitFor(() => expect(mockScheduleNotif).toHaveBeenCalled());
+    rerender({ ...base, timerState: 'paused', endsAt: 5000 });
+    await waitFor(() => expect(mockCancelNotif).toHaveBeenCalledWith('notif-1'));
+  });
+
+  it('cancels the notification on foreground completion (no stray toast)', async () => {
+    const { result } = renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: { ...base, timerState: 'running', endsAt: 5000 },
+    });
+    await waitFor(() => expect(mockScheduleNotif).toHaveBeenCalled());
+    await act(async () => {
+      await result.current.finalizeCompletedBlock();
+    });
+    expect(mockCancelNotif).toHaveBeenCalledWith('notif-1');
   });
 });
 

--- a/mobile/src/hooks/__tests__/useActiveFocusSession.test.ts
+++ b/mobile/src/hooks/__tests__/useActiveFocusSession.test.ts
@@ -43,6 +43,7 @@ interface Props {
   endsAt: number | null;
   durationMinutes: number;
   taskLabel: string | null;
+  initialCompletedSessionId?: string | null;
 }
 
 const base: Props = {
@@ -170,6 +171,15 @@ describe('completion notification', () => {
       await result.current.finalizeCompletedBlock();
     });
     expect(mockCancelNotif).toHaveBeenCalledWith('notif-1');
+  });
+});
+
+describe('cold-launch deep-link binding', () => {
+  it('seeds the last focus-session id so the inline reflection binds to it', () => {
+    const { result } = renderHook((p: Props) => useActiveFocusSession(p), {
+      initialProps: { ...base, initialCompletedSessionId: 'fs-bound' },
+    });
+    expect(result.current.getLastFocusSessionId()).toBe('fs-bound');
   });
 });
 

--- a/mobile/src/hooks/__tests__/useTimer.test.ts
+++ b/mobile/src/hooks/__tests__/useTimer.test.ts
@@ -1,0 +1,150 @@
+/**
+ * useTimer — timestamp + foreground reconciliation (B-3c.2, commit 1).
+ *
+ * The visible JS interval drives a smooth countdown, but `endsAt` (epoch ms,
+ * set when a running phase begins) is the source of truth. iOS suspends JS
+ * timers while backgrounded, so on returning to the foreground the timer must
+ * recompute remaining from `Date.now()` vs `endsAt` — and, if `endsAt` already
+ * passed, transition to completion (firing the same onSessionComplete path so
+ * the row write + completion surface still happen).
+ *
+ * Backgrounding is simulated by advancing the SYSTEM clock (jest.setSystemTime)
+ * WITHOUT running the interval — i.e. the wall clock moves while the frozen JS
+ * interval does not tick. Foregrounding is simulated by firing the captured
+ * AppState 'active' handler.
+ */
+
+import { act, renderHook } from '@testing-library/react-native';
+import { AppState, AppStateStatus } from 'react-native';
+import { useTimer } from '../useTimer';
+
+let appStateHandlers: Array<(s: AppStateStatus) => void> = [];
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  appStateHandlers = [];
+  jest
+    .spyOn(AppState, 'addEventListener')
+    .mockImplementation((_type, handler) => {
+      appStateHandlers.push(handler as (s: AppStateStatus) => void);
+      // Honor remove() so only the latest (current-closure) handler survives —
+      // mirrors the effect cleanup re-subscribing on each state transition.
+      return {
+        remove: () => {
+          appStateHandlers = appStateHandlers.filter(
+            (h) => h !== (handler as (s: AppStateStatus) => void)
+          );
+        },
+      } as never;
+    });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+/** Simulate the app returning to the foreground. */
+function foreground() {
+  act(() => {
+    appStateHandlers.forEach((h) => h('active' as AppStateStatus));
+  });
+}
+
+describe('useTimer — foreground reconciliation', () => {
+  it('completes the session when returning to foreground after endsAt passed', () => {
+    const onSessionComplete = jest.fn();
+    const { result } = renderHook(() =>
+      useTimer({ durationMinutes: 1, onSessionComplete })
+    );
+
+    act(() => {
+      result.current.start();
+    });
+    expect(result.current.state).toBe('running');
+
+    // App backgrounded for longer than the 1-min block (interval frozen).
+    act(() => {
+      jest.setSystemTime(Date.now() + 61_000);
+    });
+    foreground();
+
+    expect(result.current.state).toBe('session_complete');
+    expect(result.current.remainingSeconds).toBe(0);
+    expect(onSessionComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('recomputes remaining from the timestamp when foregrounded mid-block', () => {
+    const { result } = renderHook(() => useTimer({ durationMinutes: 5 }));
+
+    act(() => {
+      result.current.start();
+    });
+
+    // 90s elapse while backgrounded (interval frozen, wall clock advances).
+    act(() => {
+      jest.setSystemTime(Date.now() + 90_000);
+    });
+    foreground();
+
+    // 5:00 - 1:30 = 3:30 = 210s remaining.
+    expect(result.current.remainingSeconds).toBe(210);
+    expect(result.current.state).toBe('running');
+  });
+
+  it('does not complete or drift while paused across a wall-clock gap', () => {
+    const { result } = renderHook(() => useTimer({ durationMinutes: 5 }));
+
+    act(() => {
+      result.current.start();
+    });
+    // Run 10s via the live interval.
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+    expect(result.current.remainingSeconds).toBe(290);
+
+    act(() => {
+      result.current.pause();
+    });
+    // 10 min of wall clock pass while paused.
+    act(() => {
+      jest.setSystemTime(Date.now() + 600_000);
+    });
+    foreground();
+
+    expect(result.current.state).toBe('paused');
+    expect(result.current.remainingSeconds).toBe(290);
+  });
+
+  it('re-derives endsAt on resume so a later foreground reconciles correctly', () => {
+    const { result } = renderHook(() => useTimer({ durationMinutes: 5 }));
+
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+    expect(result.current.remainingSeconds).toBe(290);
+
+    act(() => {
+      result.current.pause();
+    });
+    // Long pause, then resume.
+    act(() => {
+      jest.setSystemTime(Date.now() + 600_000);
+    });
+    act(() => {
+      result.current.resume();
+    });
+    expect(result.current.state).toBe('running');
+
+    // 30s of background after resume → 290 - 30 = 260 remaining.
+    act(() => {
+      jest.setSystemTime(Date.now() + 30_000);
+    });
+    foreground();
+    expect(result.current.remainingSeconds).toBe(260);
+  });
+});

--- a/mobile/src/hooks/__tests__/useTimer.test.ts
+++ b/mobile/src/hooks/__tests__/useTimer.test.ts
@@ -117,6 +117,24 @@ describe('useTimer — foreground reconciliation', () => {
     expect(result.current.remainingSeconds).toBe(290);
   });
 
+  it('completeNow() shows the completion surface without re-writing a row', () => {
+    // Cold-launch deep link: the row was already finalized by the launch
+    // handler, so entering session_complete must NOT fire onSessionComplete
+    // (which would write a duplicate).
+    const onSessionComplete = jest.fn();
+    const { result } = renderHook(() =>
+      useTimer({ durationMinutes: 25, onSessionComplete })
+    );
+
+    act(() => {
+      result.current.completeNow();
+    });
+
+    expect(result.current.state).toBe('session_complete');
+    expect(result.current.remainingSeconds).toBe(0);
+    expect(onSessionComplete).not.toHaveBeenCalled();
+  });
+
   it('re-derives endsAt on resume so a later foreground reconciles correctly', () => {
     const { result } = renderHook(() => useTimer({ durationMinutes: 5 }));
 

--- a/mobile/src/hooks/useActiveFocusSession.ts
+++ b/mobile/src/hooks/useActiveFocusSession.ts
@@ -46,6 +46,12 @@ interface UseActiveFocusSessionParams {
   endsAt: number | null;
   durationMinutes: number;
   taskLabel: string | null;
+  /**
+   * Cold-launch deep link: the focusSessions id this surface was opened to
+   * reflect on. Seeds the last-finalized id so the inline reflection chip binds
+   * to that block's doc (the row was already finalized by the launch handler).
+   */
+  initialCompletedSessionId?: string | null;
 }
 
 interface UseActiveFocusSessionReturn {
@@ -71,12 +77,14 @@ export function useActiveFocusSession({
   endsAt,
   durationMinutes,
   taskLabel,
+  initialCompletedSessionId = null,
 }: UseActiveFocusSessionParams): UseActiveFocusSessionReturn {
   // The current block's stable id (minted at start) and wall-clock start.
   const activeIdRef = useRef<string | null>(null);
   const activeStartedAtRef = useRef<number>(0);
-  // Most recently finalized id, for the inline reflection write.
-  const lastIdRef = useRef<string | null>(null);
+  // Most recently finalized id, for the inline reflection write. Seeded from a
+  // cold-launch deep link so the reflection binds without a live completion.
+  const lastIdRef = useRef<string | null>(initialCompletedSessionId);
   // Scheduled completion-notification id, so it can be cancelled.
   const notifIdRef = useRef<string | null>(null);
 

--- a/mobile/src/hooks/useActiveFocusSession.ts
+++ b/mobile/src/hooks/useActiveFocusSession.ts
@@ -34,6 +34,10 @@ import {
   type ActiveFocusSession,
   type FocusSessionType,
 } from '../services/firebase/focusSession.service';
+import {
+  scheduleFocusCompletionNotification,
+  cancelScheduledNotification,
+} from '../services/notifications.service';
 import { logger } from '../utils/logger';
 
 interface UseActiveFocusSessionParams {
@@ -73,6 +77,17 @@ export function useActiveFocusSession({
   const activeStartedAtRef = useRef<number>(0);
   // Most recently finalized id, for the inline reflection write.
   const lastIdRef = useRef<string | null>(null);
+  // Scheduled completion-notification id, so it can be cancelled.
+  const notifIdRef = useRef<string | null>(null);
+
+  // Cancel the pending completion notification (if any). Called when the block
+  // pauses / resets / completes in the FOREGROUND (the foreground handler would
+  // otherwise route it to a stray toast) / is abandoned on unmount.
+  const cancelNotif = useCallback(() => {
+    const nid = notifIdRef.current;
+    notifIdRef.current = null;
+    if (nid) cancelScheduledNotification(nid).catch(() => {});
+  }, []);
 
   // Latest values so finalizeCompletedBlock (a stable callback) is never stale.
   const userIdRef = useRef(userId);
@@ -93,8 +108,9 @@ export function useActiveFocusSession({
         activeStartedAtRef.current = Date.now();
       }
       if (endsAt != null) {
+        const id = activeIdRef.current;
         const record: ActiveFocusSession = {
-          focusSessionId: activeIdRef.current,
+          focusSessionId: id,
           userId,
           durationMinutes,
           type: focusType(durationMinutes),
@@ -105,13 +121,25 @@ export function useActiveFocusSession({
         saveActiveFocusSession(record).catch((error) =>
           logger.warn('[useActiveFocusSession] persist failed', error)
         );
+        // (Re)schedule the OS-owned completion notification for endsAt. Cancel
+        // any previous one first so a resume (new endsAt) does not leave a
+        // stale notification behind.
+        cancelNotif();
+        scheduleFocusCompletionNotification(id, endsAt)
+          .then((nid) => {
+            notifIdRef.current = nid;
+          })
+          .catch((error) =>
+            logger.warn('[useActiveFocusSession] schedule notif failed', error)
+          );
       }
     } else if (timerState === 'paused') {
       // Kill-while-paused must not finalize: drop the record, keep the id so
-      // resume re-persists the same block.
+      // resume re-persists the same block. Cancel the pending notification too.
       clearActiveFocusSession().catch(() => {});
+      cancelNotif();
     }
-  }, [timerState, endsAt, userId, durationMinutes, taskLabel]);
+  }, [timerState, endsAt, userId, durationMinutes, taskLabel, cancelNotif]);
 
   // App-return sweep: a persisted record whose endsAt already passed is a block
   // that elapsed while backgrounded or killed → write its completion row.
@@ -147,7 +175,21 @@ export function useActiveFocusSession({
     };
   }, [userId]);
 
+  // Abandon a running block on unmount (navigating away from the timer). Screen
+  // sleep / backgrounding do NOT unmount React components, so this fires only on
+  // a deliberate departure: cancel the notification and drop the record so it is
+  // never finalized later as a fabricated completion.
+  useEffect(() => {
+    return () => {
+      cancelNotif();
+      clearActiveFocusSession().catch(() => {});
+    };
+  }, [cancelNotif]);
+
   const finalizeCompletedBlock = useCallback(async (): Promise<string | null> => {
+    // Foreground completion: cancel the OS notification so it cannot surface as
+    // a stray toast right after the in-app completion.
+    cancelNotif();
     const uid = userIdRef.current;
     if (!uid) {
       activeIdRef.current = null;
@@ -172,12 +214,13 @@ export function useActiveFocusSession({
     activeIdRef.current = null;
     await clearActiveFocusSession();
     return id;
-  }, []);
+  }, [cancelNotif]);
 
   const clearActiveBlock = useCallback(() => {
     activeIdRef.current = null;
     clearActiveFocusSession().catch(() => {});
-  }, []);
+    cancelNotif();
+  }, [cancelNotif]);
 
   const getLastFocusSessionId = useCallback(() => lastIdRef.current, []);
 

--- a/mobile/src/hooks/useActiveFocusSession.ts
+++ b/mobile/src/hooks/useActiveFocusSession.ts
@@ -1,0 +1,187 @@
+/**
+ * useActiveFocusSession (Four-Pillar IA Phase B-3c.2).
+ *
+ * Owns the persisted active-session record across a focus block's lifecycle so
+ * the focusSessions completion row can be finalized from persisted data on ANY
+ * app return — whether the app was merely backgrounded (live timer reconciles)
+ * or killed (no live timer survives):
+ *
+ *   - When a focus block enters the running state, mint a stable focusSessions
+ *     id (once per block) and persist an active record carrying the endsAt
+ *     timestamp. Resuming re-saves the same id with the new endsAt.
+ *   - Pausing drops the persisted record (a paused-then-killed block must not be
+ *     finalized) while keeping the id so resume re-persists the same block.
+ *   - On mount the hook sweeps for a persisted record whose endsAt already
+ *     passed — a block that elapsed while backgrounded or killed — and writes
+ *     its completion row (Option A: an elapsed block counts as complete).
+ *   - finalizeCompletedBlock() writes the row for the just-completed block from
+ *     the live timer (warm path / foreground reconcile) under the same stable
+ *     id; getLastFocusSessionId() exposes it so the inline reflection can bind.
+ *
+ * Breaks are NOT persisted (focus blocks only). All writes are idempotent via
+ * the stable id (setDoc merge), so the warm, reconcile, and startup paths can
+ * never produce a duplicate row.
+ */
+import { useCallback, useEffect, useRef } from 'react';
+import type { TimerState } from './useTimer';
+import {
+  clearActiveFocusSession,
+  finalizeFocusSession,
+  getActiveFocusSession,
+  isFocusSessionElapsed,
+  mintFocusSessionId,
+  saveActiveFocusSession,
+  type ActiveFocusSession,
+  type FocusSessionType,
+} from '../services/firebase/focusSession.service';
+import { logger } from '../utils/logger';
+
+interface UseActiveFocusSessionParams {
+  userId: string | null;
+  timerState: TimerState;
+  endsAt: number | null;
+  durationMinutes: number;
+  taskLabel: string | null;
+}
+
+interface UseActiveFocusSessionReturn {
+  /**
+   * Write the completion row for the just-completed block (call from the
+   * timer's onSessionComplete). Returns the stable focusSessions id written, or
+   * null when there is no user.
+   */
+  finalizeCompletedBlock: () => Promise<string | null>;
+  /** Drop the active block + record (call from reset / done-for-now). */
+  clearActiveBlock: () => void;
+  /** Most recently finalized focusSessions id, for inline-reflection binding. */
+  getLastFocusSessionId: () => string | null;
+}
+
+function focusType(durationMinutes: number): FocusSessionType {
+  return durationMinutes === 90 ? 'ultradian' : 'pomodoro';
+}
+
+export function useActiveFocusSession({
+  userId,
+  timerState,
+  endsAt,
+  durationMinutes,
+  taskLabel,
+}: UseActiveFocusSessionParams): UseActiveFocusSessionReturn {
+  // The current block's stable id (minted at start) and wall-clock start.
+  const activeIdRef = useRef<string | null>(null);
+  const activeStartedAtRef = useRef<number>(0);
+  // Most recently finalized id, for the inline reflection write.
+  const lastIdRef = useRef<string | null>(null);
+
+  // Latest values so finalizeCompletedBlock (a stable callback) is never stale.
+  const userIdRef = useRef(userId);
+  const durationRef = useRef(durationMinutes);
+  const taskRef = useRef(taskLabel);
+  useEffect(() => {
+    userIdRef.current = userId;
+    durationRef.current = durationMinutes;
+    taskRef.current = taskLabel;
+  });
+
+  // Persist while a focus block runs; drop the record while paused.
+  useEffect(() => {
+    if (timerState === 'running') {
+      if (!userId) return;
+      if (!activeIdRef.current) {
+        activeIdRef.current = mintFocusSessionId();
+        activeStartedAtRef.current = Date.now();
+      }
+      if (endsAt != null) {
+        const record: ActiveFocusSession = {
+          focusSessionId: activeIdRef.current,
+          userId,
+          durationMinutes,
+          type: focusType(durationMinutes),
+          taskLabel,
+          startedAt: activeStartedAtRef.current,
+          endsAt,
+        };
+        saveActiveFocusSession(record).catch((error) =>
+          logger.warn('[useActiveFocusSession] persist failed', error)
+        );
+      }
+    } else if (timerState === 'paused') {
+      // Kill-while-paused must not finalize: drop the record, keep the id so
+      // resume re-persists the same block.
+      clearActiveFocusSession().catch(() => {});
+    }
+  }, [timerState, endsAt, userId, durationMinutes, taskLabel]);
+
+  // App-return sweep: a persisted record whose endsAt already passed is a block
+  // that elapsed while backgrounded or killed → write its completion row.
+  useEffect(() => {
+    if (!userId) return;
+    let active = true;
+    (async () => {
+      const rec = await getActiveFocusSession();
+      if (!active || !rec || rec.userId !== userId) return;
+      // Killed mid-block (endsAt still in the future) → leave the record to be
+      // superseded by the next start; do not fabricate a completion.
+      if (!isFocusSessionElapsed(rec, Date.now())) return;
+      try {
+        await finalizeFocusSession({
+          focusSessionId: rec.focusSessionId,
+          userId: rec.userId,
+          durationMinutes: rec.durationMinutes,
+          type: rec.type,
+          taskLabel: rec.taskLabel,
+        });
+        lastIdRef.current = rec.focusSessionId;
+      } catch (error) {
+        logger.error('[useActiveFocusSession] finalize-on-return failed', error);
+      }
+      // Only clear if no new block has started since (avoids nuking a record a
+      // fresh start just wrote).
+      if (activeIdRef.current === null) {
+        await clearActiveFocusSession();
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [userId]);
+
+  const finalizeCompletedBlock = useCallback(async (): Promise<string | null> => {
+    const uid = userIdRef.current;
+    if (!uid) {
+      activeIdRef.current = null;
+      await clearActiveFocusSession();
+      return null;
+    }
+    // The block always had a running-persist that minted the id; fall back to a
+    // fresh id only defensively so a completed block always writes a row.
+    const id = activeIdRef.current ?? mintFocusSessionId();
+    try {
+      await finalizeFocusSession({
+        focusSessionId: id,
+        userId: uid,
+        durationMinutes: durationRef.current,
+        type: focusType(durationRef.current),
+        taskLabel: taskRef.current,
+      });
+      lastIdRef.current = id;
+    } catch (error) {
+      logger.error('[useActiveFocusSession] finalize failed', error);
+    }
+    activeIdRef.current = null;
+    await clearActiveFocusSession();
+    return id;
+  }, []);
+
+  const clearActiveBlock = useCallback(() => {
+    activeIdRef.current = null;
+    clearActiveFocusSession().catch(() => {});
+  }, []);
+
+  const getLastFocusSessionId = useCallback(() => lastIdRef.current, []);
+
+  return { finalizeCompletedBlock, clearActiveBlock, getLastFocusSessionId };
+}
+
+export default useActiveFocusSession;

--- a/mobile/src/hooks/useTimer.ts
+++ b/mobile/src/hooks/useTimer.ts
@@ -12,6 +12,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
 import * as Haptics from 'expo-haptics';
 
 export type TimerState =
@@ -81,6 +82,30 @@ export const useTimer = ({
   const [breakMinutes, setBreakMinutes] = useState(initialBreakMinutes);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
+  // Epoch-ms timestamp the current running phase should hit 0. This is the
+  // SOURCE OF TRUTH for time elapsed: the visible JS interval is only for a
+  // smooth display and is frozen by iOS while backgrounded, so on returning to
+  // the foreground we reconcile remaining from Date.now() vs endsAt. Null
+  // whenever the timer is not in a running phase.
+  const endsAtRef = useRef<number | null>(null);
+
+  // Mirror of remainingSeconds for fresh reads inside callbacks/handlers
+  // (useCallback closures and the AppState handler would otherwise see a stale
+  // value). Kept in sync below.
+  const remainingRef = useRef(remainingSeconds);
+  useEffect(() => {
+    remainingRef.current = remainingSeconds;
+  }, [remainingSeconds]);
+
+  // Latest-callback refs so the foreground-reconciliation effect can complete a
+  // phase without listing the (often inline) callbacks in its deps.
+  const onSessionCompleteRef = useRef(onSessionComplete);
+  const onBreakCompleteRef = useRef(onBreakComplete);
+  useEffect(() => {
+    onSessionCompleteRef.current = onSessionComplete;
+    onBreakCompleteRef.current = onBreakComplete;
+  });
+
   // Clear interval on unmount
   useEffect(() => {
     return () => {
@@ -108,6 +133,7 @@ export const useTimer = ({
 
           if (newValue <= 0) {
             clearInterval(intervalRef.current!);
+            endsAtRef.current = null;
 
             if (state === 'running') {
               // Session complete
@@ -141,9 +167,45 @@ export const useTimer = ({
     };
   }, [state, onSessionComplete, onBreakComplete, onTick]);
 
+  // Foreground reconciliation. iOS suspends the JS interval while backgrounded,
+  // so on returning to 'active' we recompute remaining from the wall clock. If
+  // endsAt has already passed, transition to completion via the SAME path the
+  // interval would have taken (so the completion surface + row write happen);
+  // otherwise correct the displayed remaining for the elapsed background time.
+  useEffect(() => {
+    const reconcile = (next: AppStateStatus) => {
+      if (next !== 'active') return;
+      if (state !== 'running' && state !== 'break_running') return;
+      if (endsAtRef.current == null) return;
+
+      const remainingMs = endsAtRef.current - Date.now();
+      if (remainingMs <= 0) {
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+        }
+        endsAtRef.current = null;
+        setRemainingSeconds(0);
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        if (state === 'running') {
+          setState('session_complete');
+          onSessionCompleteRef.current?.();
+        } else {
+          setState('break_complete');
+          onBreakCompleteRef.current?.();
+        }
+      } else {
+        setRemainingSeconds(Math.ceil(remainingMs / 1000));
+      }
+    };
+
+    const subscription = AppState.addEventListener('change', reconcile);
+    return () => subscription.remove();
+  }, [state]);
+
   const start = useCallback(() => {
     if (state === 'idle') {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      endsAtRef.current = Date.now() + remainingRef.current * 1000;
       setState('running');
     }
   }, [state]);
@@ -151,6 +213,8 @@ export const useTimer = ({
   const pause = useCallback(() => {
     if (state === 'running' || state === 'break_running') {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      // Freeze: remaining is preserved in state; endsAt is re-derived on resume.
+      endsAtRef.current = null;
       setState('paused');
     }
   }, [state]);
@@ -158,6 +222,7 @@ export const useTimer = ({
   const resume = useCallback(() => {
     if (state === 'paused') {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      endsAtRef.current = Date.now() + remainingRef.current * 1000;
       // Resume to the previous active state
       setState('running'); // Simplified - could track previous state
     }
@@ -168,6 +233,7 @@ export const useTimer = ({
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
     }
+    endsAtRef.current = null;
     const seconds = durationMinutes * 60;
     setRemainingSeconds(seconds);
     setTotalSeconds(seconds);
@@ -180,6 +246,7 @@ export const useTimer = ({
       const breakSeconds = breakMinutes * 60;
       setRemainingSeconds(breakSeconds);
       setTotalSeconds(breakSeconds);
+      endsAtRef.current = Date.now() + breakSeconds * 1000;
       setState('break_running');
     }
   }, [state, breakMinutes]);
@@ -195,6 +262,7 @@ export const useTimer = ({
       const seconds = durationMinutes * 60;
       setRemainingSeconds(seconds);
       setTotalSeconds(seconds);
+      endsAtRef.current = Date.now() + seconds * 1000;
       setState('running');
     }
   }, [state, durationMinutes]);

--- a/mobile/src/hooks/useTimer.ts
+++ b/mobile/src/hooks/useTimer.ts
@@ -66,6 +66,12 @@ interface UseTimerReturn {
   startBreak: () => void;
   /** Begin another session (from break_complete state) */
   beginAnother: () => void;
+  /**
+   * Force the completion surface WITHOUT firing onSessionComplete. Used by the
+   * cold-launch deep link: the focusSessions row was already finalized by the
+   * launch handler, so re-firing onSessionComplete would write a duplicate.
+   */
+  completeNow: () => void;
   /** Check if timer is in a break state */
   isBreak: boolean;
   /** Check if timer is active (running or break_running) */
@@ -274,6 +280,15 @@ export const useTimer = ({
     }
   }, [state, durationMinutes]);
 
+  const completeNow = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    endsAtRef.current = null;
+    setRemainingSeconds(0);
+    setState('session_complete');
+  }, []);
+
   // Calculate progress (0 to 1)
   const progress = totalSeconds > 0 ? (totalSeconds - remainingSeconds) / totalSeconds : 0;
 
@@ -297,6 +312,7 @@ export const useTimer = ({
     reset,
     startBreak,
     beginAnother,
+    completeNow,
     isBreak: state === 'break_running' || state === 'break_complete',
     isActive: state === 'running' || state === 'break_running',
     breakDurationMinutes: breakMinutes,

--- a/mobile/src/hooks/useTimer.ts
+++ b/mobile/src/hooks/useTimer.ts
@@ -43,6 +43,13 @@ interface UseTimerReturn {
   remainingSeconds: number;
   /** Total duration in seconds */
   totalSeconds: number;
+  /**
+   * Epoch ms the current running phase is scheduled to hit 0, or null when not
+   * in a running phase. The timestamp source of truth (see foreground
+   * reconciliation); exposed so the caller can persist it / schedule a
+   * completion notification keyed to it.
+   */
+  endsAt: number | null;
   /** Progress from 0 to 1 */
   progress: number;
   /** Formatted time string (MM:SS) */
@@ -281,6 +288,7 @@ export const useTimer = ({
     state,
     remainingSeconds,
     totalSeconds,
+    endsAt: endsAtRef.current,
     progress,
     formattedTime: formatTime(remainingSeconds),
     start,

--- a/mobile/src/screens/Focus/FocusScreen.tsx
+++ b/mobile/src/screens/Focus/FocusScreen.tsx
@@ -57,7 +57,15 @@ const CENTER_FIRST_PROTOCOL_ID = 'box-breathing-2';
 type FocusRoute = RouteProp<
   {
     FocusTimer:
-      | { fromCheckIn?: boolean; fromHub?: boolean; durationMinutes?: number }
+      | {
+          fromCheckIn?: boolean;
+          fromHub?: boolean;
+          durationMinutes?: number;
+          // Cold-launch deep link from a completion-notification tap (B-3c.2):
+          // the already-finalized focusSessions id to open the completion
+          // surface on.
+          completedSessionId?: string;
+        }
       | undefined;
   },
   'FocusTimer'
@@ -76,6 +84,8 @@ export const FocusScreen: React.FC = () => {
   const shouldExitOnDone = fromCheckIn || fromHub;
   // Budget-derived prefill length from the check-in's focus-session pointer.
   const initialDuration = route.params?.durationMinutes;
+  // Cold-launch deep link: the already-finalized block to reflect on.
+  const completedSessionId = route.params?.completedSessionId;
 
   // Center-first state. `centerFirst` controls the setup row (initialized from
   // the persisted preference). `centering` flips while the box breathing
@@ -211,6 +221,7 @@ export const FocusScreen: React.FC = () => {
           onCenterFirstBegin={canCenter ? handleCenterFirstBegin : undefined}
           onExit={shouldExitOnDone ? handleExit : undefined}
           onBlockReflect={handleBlockReflect}
+          completedSessionId={completedSessionId}
         />
       </View>
     </SafeAreaView>

--- a/mobile/src/screens/Focus/PomodoroTab.tsx
+++ b/mobile/src/screens/Focus/PomodoroTab.tsx
@@ -81,6 +81,14 @@ interface PomodoroTabProps {
   onToggleCenterFirst?: (next: boolean) => void;
   onCenterFirstBegin?: (durationMinutes: number) => void;
   autoStart?: boolean;
+  /**
+   * Cold-launch deep link (B-3c.2). When a completion notification is tapped
+   * from a killed/backgrounded app, the focusSessions row is already finalized
+   * by the launch handler; this is its id. On mount the timer opens directly on
+   * the B-3c.1 completion surface bound to it, so the inline reflection chip
+   * writes via the existing onBlockReflect(reflectionId, blockId) path.
+   */
+  completedSessionId?: string;
 }
 
 export const PomodoroTab: React.FC<PomodoroTabProps> = ({
@@ -92,6 +100,7 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
   onToggleCenterFirst,
   onCenterFirstBegin,
   autoStart = false,
+  completedSessionId,
 }) => {
   const { user } = useAuth();
   const { playCompletionSound } = useCompletionSound();
@@ -127,6 +136,7 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
     endsAt: timer.endsAt,
     durationMinutes: selectedDuration,
     taskLabel: taskLabel || null,
+    initialCompletedSessionId: completedSessionId ?? null,
   });
 
   // Ambient sound hook
@@ -216,10 +226,19 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
     }
   }, [timer, centerFirst, onCenterFirstBegin, selectedDuration]);
 
+  // Cold-launch deep link: open directly on the completion surface bound to the
+  // already-finalized block. Mount-only; takes precedence over autoStart (the
+  // two never co-occur — one is a completion tap, the other a centering handoff).
+  useEffect(() => {
+    if (!completedSessionId) return;
+    timer.completeNow();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Auto-start when handed back from the centering practice (no second tap).
   // Mount-only; the small delay mirrors handleStartAnother's reset→start gap.
   useEffect(() => {
-    if (!autoStart) return;
+    if (!autoStart || completedSessionId) return;
     const id = setTimeout(() => timer.start(), 50);
     return () => clearTimeout(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/mobile/src/screens/Focus/PomodoroTab.tsx
+++ b/mobile/src/screens/Focus/PomodoroTab.tsx
@@ -10,13 +10,11 @@
  * - Notification toggle and ambient sound selector
  */
 
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { View, StyleSheet, ScrollView, TouchableOpacity, Text } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAuth } from '../../context/AuthContext';
-import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
-import { db } from '../../config/firebase';
 import {
   ColorTokens,
   SpacingTokens,
@@ -28,6 +26,7 @@ import {
 import { FocusCopy } from '../../constants/focusContent';
 import { useTimer, useAmbientSound } from '../../hooks';
 import { useCompletionSound } from '../../hooks/useCompletionSound';
+import { useActiveFocusSession } from '../../hooks/useActiveFocusSession';
 import {
   DurationChips,
   TaskLabelInput,
@@ -97,10 +96,6 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
   const { user } = useAuth();
   const { playCompletionSound } = useCompletionSound();
 
-  // Most recently completed focus-session doc id, so the loop-done reflection
-  // can attach to it (light interim write). Null until a block completes.
-  const lastFocusSessionIdRef = useRef<string | null>(null);
-
   // Task label state
   const [taskLabel, setTaskLabel] = useState('');
 
@@ -121,6 +116,17 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
     breakDurationMinutes: 5,
     onSessionComplete: handleSessionComplete,
     onBreakComplete: handleBreakComplete,
+  });
+
+  // Persisted active-session record. Survives screen-sleep / backgrounding /
+  // kill: the focusSessions completion row is finalized from this record on any
+  // app return (B-3c.2). Breaks are not persisted.
+  const focusSession = useActiveFocusSession({
+    userId: user?.uid ?? null,
+    timerState: timer.state,
+    endsAt: timer.endsAt,
+    durationMinutes: selectedDuration,
+    taskLabel: taskLabel || null,
   });
 
   // Ambient sound hook
@@ -164,39 +170,29 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
     }
   }, [timer.isActive, timer.state]);
 
-  // Session complete handler - log to Firestore
+  // Session complete handler. Finalizes the focusSessions completion row from
+  // the persisted active-session record under its stable id (idempotent), so
+  // the warm path and a foreground reconcile converge on the same doc.
   async function handleSessionComplete() {
     playCompletionSound();
-    if (user && db) {
-      try {
-        const ref = await addDoc(collection(db, 'focusSessions'), {
-          userId: user.uid,
-          duration: selectedDuration,
-          type: selectedDuration === 90 ? 'ultradian' : 'pomodoro',
-          completed: true,
-          startedAt: serverTimestamp(),
-          endedAt: serverTimestamp(),
-          taskLabel: taskLabel || null,
-          interrupted: false,
-        });
-        lastFocusSessionIdRef.current = ref.id;
-        console.log('Focus session logged successfully');
-      } catch (error) {
-        console.error('Error logging focus session:', error);
-      }
-    } else if (!db) {
-      console.warn('Firebase not initialized, cannot log focus session');
-    }
+    await focusSession.finalizeCompletedBlock();
   }
 
   function handleBreakComplete() {
     console.log('Break complete');
   }
 
+  // A user-initiated reset abandons the current block: clear the persisted
+  // active record (and minted id) so it is never finalized on a later return.
+  const handleReset = useCallback(() => {
+    focusSession.clearActiveBlock();
+    timer.reset();
+  }, [focusSession, timer]);
+
   const handleDurationChange = useCallback((duration: number) => {
     setSelectedDuration(duration);
-    timer.reset();
-  }, [timer]);
+    handleReset();
+  }, [handleReset]);
 
   const handlePlayPause = useCallback(() => {
     const action = resolvePlayAction(timer.state, {
@@ -246,9 +242,9 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
   const handleSelectReflection = useCallback(
     (reflectionId: string) => {
       setSelectedReflectionId(reflectionId);
-      onBlockReflect?.(reflectionId, lastFocusSessionIdRef.current);
+      onBlockReflect?.(reflectionId, focusSession.getLastFocusSessionId());
     },
-    [onBlockReflect]
+    [onBlockReflect, focusSession]
   );
 
   // "Done for now" terminal. Hub/check-in launched: hand back to the parent to
@@ -260,8 +256,8 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
       onExit();
       return;
     }
-    timer.reset();
-  }, [onExit, timer]);
+    handleReset();
+  }, [onExit, handleReset]);
 
   const toggleSoundPanel = useCallback(() => {
     setIsSoundPanelOpen((prev) => !prev);
@@ -369,7 +365,7 @@ export const PomodoroTab: React.FC<PomodoroTabProps> = ({
         <View style={styles.controls}>
           <TouchableOpacity
             style={styles.controlButton}
-            onPress={timer.reset}
+            onPress={handleReset}
             accessibilityRole="button"
             accessibilityLabel="Reset timer"
           >

--- a/mobile/src/services/__tests__/notifications.service.focus.test.ts
+++ b/mobile/src/services/__tests__/notifications.service.focus.test.ts
@@ -1,0 +1,96 @@
+/**
+ * notifications.service — focus-completion scheduling + permission gating
+ * (B-3c.2 commit 3). Verifies the completion notification carries the
+ * focus-complete deep-link data, fires on a DATE trigger at endsAt, and
+ * DEGRADES GRACEFULLY (returns null, schedules nothing) when permission is
+ * denied. expo-notifications is fully mocked.
+ */
+
+const mockSchedule = jest.fn((..._a: unknown[]) => Promise.resolve('notif-1'));
+const mockGetPerms = jest.fn((): Promise<{ status: string }> =>
+  Promise.resolve({ status: 'granted' })
+);
+const mockRequestPerms = jest.fn((): Promise<{ status: string }> =>
+  Promise.resolve({ status: 'granted' })
+);
+
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: (...a: unknown[]) => mockSchedule(...a),
+  getPermissionsAsync: () => mockGetPerms(),
+  requestPermissionsAsync: () => mockRequestPerms(),
+  cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
+  cancelAllScheduledNotificationsAsync: jest.fn(() => Promise.resolve()),
+  getAllScheduledNotificationsAsync: jest.fn(() => Promise.resolve([])),
+  addNotificationReceivedListener: jest.fn(),
+  addNotificationResponseReceivedListener: jest.fn(),
+  setNotificationHandler: jest.fn(),
+  setNotificationChannelAsync: jest.fn(),
+  AndroidImportance: { HIGH: 4 },
+  AndroidNotificationPriority: { HIGH: 'high' },
+  SchedulableTriggerInputTypes: { DATE: 'date', DAILY: 'daily' },
+}));
+
+jest.mock('expo-device', () => ({ isDevice: true }));
+jest.mock('../../config/firebase', () => ({ db: null }));
+
+import {
+  ensureNotificationPermission,
+  scheduleFocusCompletionNotification,
+} from '../notifications.service';
+
+beforeEach(() => {
+  mockSchedule.mockClear();
+  mockSchedule.mockResolvedValue('notif-1');
+  mockGetPerms.mockReset();
+  mockGetPerms.mockResolvedValue({ status: 'granted' });
+  mockRequestPerms.mockReset();
+  mockRequestPerms.mockResolvedValue({ status: 'granted' });
+});
+
+describe('ensureNotificationPermission', () => {
+  it('returns true without prompting when already granted', async () => {
+    mockGetPerms.mockResolvedValueOnce({ status: 'granted' });
+    expect(await ensureNotificationPermission()).toBe(true);
+    expect(mockRequestPerms).not.toHaveBeenCalled();
+  });
+
+  it('requests when undetermined and reflects the result', async () => {
+    mockGetPerms.mockResolvedValueOnce({ status: 'undetermined' });
+    mockRequestPerms.mockResolvedValueOnce({ status: 'granted' });
+    expect(await ensureNotificationPermission()).toBe(true);
+    expect(mockRequestPerms).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when the request is denied', async () => {
+    mockGetPerms.mockResolvedValueOnce({ status: 'undetermined' });
+    mockRequestPerms.mockResolvedValueOnce({ status: 'denied' });
+    expect(await ensureNotificationPermission()).toBe(false);
+  });
+});
+
+describe('scheduleFocusCompletionNotification', () => {
+  it('schedules a DATE-triggered notification carrying focus-complete data', async () => {
+    const endsAt = 1_700_000_000_000;
+    const id = await scheduleFocusCompletionNotification('fs-1', endsAt);
+    expect(id).toBe('notif-1');
+    expect(mockSchedule).toHaveBeenCalledTimes(1);
+    const arg = mockSchedule.mock.calls[0][0] as unknown as {
+      content: { data: Record<string, unknown> };
+      trigger: { type: string; date: number };
+    };
+    expect(arg.content.data).toEqual({
+      type: 'focus-complete',
+      focusSessionId: 'fs-1',
+      endsAt,
+    });
+    expect(arg.trigger).toEqual({ type: 'date', date: endsAt });
+  });
+
+  it('degrades gracefully: schedules nothing and returns null when denied', async () => {
+    mockGetPerms.mockResolvedValueOnce({ status: 'denied' });
+    mockRequestPerms.mockResolvedValueOnce({ status: 'denied' });
+    const id = await scheduleFocusCompletionNotification('fs-1', 123);
+    expect(id).toBeNull();
+    expect(mockSchedule).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/services/firebase/__tests__/focusSession.service.test.ts
+++ b/mobile/src/services/firebase/__tests__/focusSession.service.test.ts
@@ -1,0 +1,143 @@
+// focusSession.service — persisted active-session record + stable-id finalize
+// (B-3c.2 commit 2). Mocks precede the module-under-test import.
+
+const mockSetItem = jest.fn((_k: string, _v: string) => Promise.resolve());
+const mockGetItem = jest.fn((_k: string) => Promise.resolve(null as string | null));
+const mockRemoveItem = jest.fn((_k: string) => Promise.resolve());
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: (key: string, value: string) => mockSetItem(key, value),
+  getItem: (key: string) => mockGetItem(key),
+  removeItem: (key: string) => mockRemoveItem(key),
+}));
+
+const mockSetDoc = jest.fn((..._a: unknown[]) => Promise.resolve());
+const mockDoc = jest.fn((...args: unknown[]): unknown => ({ __ref: args }));
+const mockCollection = jest.fn((_db: unknown, name: string): unknown => ({ __coll: name }));
+jest.mock('firebase/firestore', () => ({
+  doc: (...args: unknown[]) => mockDoc(...args),
+  collection: (...args: unknown[]) => mockCollection(...(args as [unknown, string])),
+  setDoc: (...args: unknown[]) => mockSetDoc(...args),
+  serverTimestamp: () => '__TS__',
+}));
+
+jest.mock('../../../config/firebase', () => ({ db: { __mock: true } }));
+jest.mock('../../../utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), log: jest.fn() },
+}));
+
+import {
+  _FOCUS_SESSION_ACTIVE_KEY,
+  clearActiveFocusSession,
+  finalizeFocusSession,
+  getActiveFocusSession,
+  isFocusSessionElapsed,
+  mintFocusSessionId,
+  saveActiveFocusSession,
+  type ActiveFocusSession,
+} from '../focusSession.service';
+
+const sample: ActiveFocusSession = {
+  focusSessionId: 'fs-abc',
+  userId: 'u1',
+  durationMinutes: 25,
+  type: 'pomodoro',
+  taskLabel: 'Writing',
+  startedAt: 1_700_000_000_000,
+  endsAt: 1_700_000_000_000 + 25 * 60_000,
+};
+
+beforeEach(() => {
+  mockSetItem.mockClear();
+  mockGetItem.mockReset();
+  mockGetItem.mockResolvedValue(null);
+  mockRemoveItem.mockClear();
+  mockSetDoc.mockClear();
+  mockDoc.mockClear();
+  mockCollection.mockClear();
+});
+
+describe('mintFocusSessionId', () => {
+  it('returns an id from an unwritten focusSessions doc ref', () => {
+    mockDoc.mockReturnValueOnce({ id: 'minted-123' });
+    const id = mintFocusSessionId();
+    expect(mockCollection).toHaveBeenCalledWith(expect.anything(), 'focusSessions');
+    expect(id).toBe('minted-123');
+    // Minting must NOT write anything.
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+});
+
+describe('active-session record persistence', () => {
+  it('saves the record as JSON under the active key', async () => {
+    await saveActiveFocusSession(sample);
+    expect(mockSetItem).toHaveBeenCalledWith(
+      _FOCUS_SESSION_ACTIVE_KEY,
+      JSON.stringify(sample)
+    );
+  });
+
+  it('round-trips the record back from storage', async () => {
+    mockGetItem.mockResolvedValueOnce(JSON.stringify(sample));
+    const got = await getActiveFocusSession();
+    expect(got).toEqual(sample);
+  });
+
+  it('returns null when no record is stored', async () => {
+    mockGetItem.mockResolvedValueOnce(null);
+    expect(await getActiveFocusSession()).toBeNull();
+  });
+
+  it('returns null (does not throw) on a malformed record', async () => {
+    mockGetItem.mockResolvedValueOnce('{"focusSessionId":123}');
+    expect(await getActiveFocusSession()).toBeNull();
+  });
+
+  it('clears the record', async () => {
+    await clearActiveFocusSession();
+    expect(mockRemoveItem).toHaveBeenCalledWith(_FOCUS_SESSION_ACTIVE_KEY);
+  });
+});
+
+describe('finalizeFocusSession', () => {
+  it('writes the completed row to the stable focusSessions id via merge setDoc', async () => {
+    const ref = { __ref: 'focusSessions/fs-abc' };
+    mockDoc.mockReturnValueOnce(ref);
+    await finalizeFocusSession({
+      focusSessionId: 'fs-abc',
+      userId: 'u1',
+      durationMinutes: 25,
+      type: 'pomodoro',
+      taskLabel: 'Writing',
+    });
+    expect(mockDoc).toHaveBeenCalledWith(expect.anything(), 'focusSessions', 'fs-abc');
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const [passedRef, data, options] = mockSetDoc.mock.calls[0] as unknown as [
+      unknown,
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ];
+    expect(passedRef).toBe(ref);
+    expect(data).toEqual(
+      expect.objectContaining({
+        userId: 'u1',
+        duration: 25,
+        type: 'pomodoro',
+        completed: true,
+        taskLabel: 'Writing',
+        interrupted: false,
+      })
+    );
+    expect(options).toEqual({ merge: true });
+  });
+});
+
+describe('isFocusSessionElapsed', () => {
+  it('is true once the scheduled end has passed', () => {
+    expect(isFocusSessionElapsed(sample, sample.endsAt + 1)).toBe(true);
+    expect(isFocusSessionElapsed(sample, sample.endsAt)).toBe(true);
+  });
+  it('is false before the scheduled end', () => {
+    expect(isFocusSessionElapsed(sample, sample.endsAt - 1)).toBe(false);
+  });
+});

--- a/mobile/src/services/firebase/__tests__/focusSession.service.test.ts
+++ b/mobile/src/services/firebase/__tests__/focusSession.service.test.ts
@@ -33,6 +33,7 @@ import {
   getActiveFocusSession,
   isFocusSessionElapsed,
   mintFocusSessionId,
+  planFocusCompleteLaunch,
   saveActiveFocusSession,
   type ActiveFocusSession,
 } from '../focusSession.service';
@@ -129,6 +130,32 @@ describe('finalizeFocusSession', () => {
       })
     );
     expect(options).toEqual({ merge: true });
+  });
+});
+
+describe('planFocusCompleteLaunch', () => {
+  it('finalizes + binds when an elapsed record matches the user', () => {
+    const plan = planFocusCompleteLaunch(sample, 'u1', sample.endsAt + 1);
+    expect(plan.finalize).toBe(sample);
+    expect(plan.completedSessionId).toBe('fs-abc');
+  });
+
+  it('does not bind when the record is missing', () => {
+    const plan = planFocusCompleteLaunch(null, 'u1', Date.now());
+    expect(plan.finalize).toBeNull();
+    expect(plan.completedSessionId).toBeNull();
+  });
+
+  it('does not bind a record that has not elapsed yet', () => {
+    const plan = planFocusCompleteLaunch(sample, 'u1', sample.endsAt - 1);
+    expect(plan.finalize).toBeNull();
+    expect(plan.completedSessionId).toBeNull();
+  });
+
+  it('does not bind another user record', () => {
+    const plan = planFocusCompleteLaunch(sample, 'other', sample.endsAt + 1);
+    expect(plan.finalize).toBeNull();
+    expect(plan.completedSessionId).toBeNull();
   });
 });
 

--- a/mobile/src/services/firebase/focusSession.service.ts
+++ b/mobile/src/services/firebase/focusSession.service.ts
@@ -1,0 +1,164 @@
+/**
+ * Focus-session persistence (Four-Pillar IA Phase B-3c.2).
+ *
+ * A focus block's completion row in `focusSessions` is written only when the
+ * block finishes. iOS suspends the JS timer while backgrounded and may kill the
+ * app outright, so completion can no longer rely on a live in-memory timer. This
+ * module makes a focus block FINALIZABLE FROM PERSISTED DATA on any app return:
+ *
+ *   - At block START the caller mints a STABLE focusSessions id (without writing)
+ *     and persists an active-session record (AsyncStorage) carrying everything
+ *     needed to write the completion row later: the id, duration, label, and the
+ *     `endsAt` timestamp.
+ *   - On completion — warm (live timer), a foreground reconcile, or a cold
+ *     launch — the row is written via the SAME stable id with `setDoc(merge)`,
+ *     so every path converges on one idempotent doc (no duplicates) and the
+ *     active record is cleared.
+ *
+ * The completion row keeps the exact field shape the previous inline write used
+ * (duration / type / completed / startedAt / endedAt / taskLabel / interrupted)
+ * so downstream consumers (dashboard, correlation engine) are unaffected. No
+ * BrainState and no protocolId: a bare focus block is state-less and
+ * protocol-less, unchanged.
+ *
+ * Storage-only for the active record (swallows AsyncStorage errors with a
+ * warning — persistence is opportunistic, never fatal to the timer UX).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { collection, doc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from '../../config/firebase';
+import { logger } from '../../utils/logger';
+
+const ACTIVE_KEY = '@vara/focusSessionActive';
+const COLLECTION = 'focusSessions';
+
+export type FocusSessionType = 'pomodoro' | 'ultradian';
+
+export interface ActiveFocusSession {
+  /** Stable focusSessions doc id, minted at start, written at completion. */
+  focusSessionId: string;
+  userId: string;
+  durationMinutes: number;
+  type: FocusSessionType;
+  taskLabel: string | null;
+  /** Epoch ms when the block began. */
+  startedAt: number;
+  /** Epoch ms the block is scheduled to complete (the timer's endsAt). */
+  endsAt: number;
+}
+
+/**
+ * Mint a focusSessions doc id WITHOUT writing. The id is known at block start
+ * (for the active record + completion notification data) and the row is written
+ * later under the same id — so the cold-launch deep link can bind the inline
+ * reflection to a real, stable focusSessions id.
+ */
+export function mintFocusSessionId(): string {
+  if (!db) throw new Error('Firestore not initialized');
+  return doc(collection(db, COLLECTION)).id;
+}
+
+export async function saveActiveFocusSession(
+  record: ActiveFocusSession
+): Promise<void> {
+  try {
+    await AsyncStorage.setItem(ACTIVE_KEY, JSON.stringify(record));
+  } catch (error) {
+    logger.warn('focusSession: saveActiveFocusSession failed', error);
+  }
+}
+
+export async function getActiveFocusSession(): Promise<ActiveFocusSession | null> {
+  let raw: string | null;
+  try {
+    raw = await AsyncStorage.getItem(ACTIVE_KEY);
+  } catch (error) {
+    logger.warn('focusSession: getActiveFocusSession failed', error);
+    return null;
+  }
+  if (raw === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidActive(parsed)) {
+      logger.warn('focusSession: malformed active record, ignoring');
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    logger.warn('focusSession: getActiveFocusSession parse failed', error);
+    return null;
+  }
+}
+
+export async function clearActiveFocusSession(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(ACTIVE_KEY);
+  } catch (error) {
+    logger.warn('focusSession: clearActiveFocusSession failed', error);
+  }
+}
+
+export interface FinalizeFocusSessionInput {
+  focusSessionId: string;
+  userId: string;
+  durationMinutes: number;
+  type: FocusSessionType;
+  taskLabel: string | null;
+}
+
+/**
+ * Write the completed focusSessions row under the stable id. Idempotent via
+ * `setDoc(merge)`: the warm path, a foreground reconcile, and a cold-launch
+ * finalize all converge on the same doc with the same data, so a redundant
+ * second write is harmless.
+ */
+export async function finalizeFocusSession(
+  input: FinalizeFocusSessionInput
+): Promise<void> {
+  if (!db) throw new Error('Firestore not initialized');
+  const ref = doc(db, COLLECTION, input.focusSessionId);
+  await setDoc(
+    ref,
+    {
+      userId: input.userId,
+      duration: input.durationMinutes,
+      type: input.type,
+      completed: true,
+      startedAt: serverTimestamp(),
+      endedAt: serverTimestamp(),
+      taskLabel: input.taskLabel,
+      interrupted: false,
+    },
+    { merge: true }
+  );
+}
+
+/**
+ * Pure: should a persisted record be finalized as complete on app return? True
+ * once its scheduled end has passed — Option A: a block whose time elapsed,
+ * backgrounded OR killed, counts as complete (the completion notification would
+ * have fired at endsAt regardless of whether the app was running).
+ */
+export function isFocusSessionElapsed(
+  record: ActiveFocusSession,
+  nowMs: number
+): boolean {
+  return record.endsAt <= nowMs;
+}
+
+// Test-only export.
+export const _FOCUS_SESSION_ACTIVE_KEY = ACTIVE_KEY;
+
+function isValidActive(x: unknown): x is ActiveFocusSession {
+  if (x === null || typeof x !== 'object') return false;
+  const o = x as Partial<ActiveFocusSession>;
+  return (
+    typeof o.focusSessionId === 'string' &&
+    typeof o.userId === 'string' &&
+    typeof o.durationMinutes === 'number' &&
+    (o.type === 'pomodoro' || o.type === 'ultradian') &&
+    (o.taskLabel === null || typeof o.taskLabel === 'string') &&
+    typeof o.startedAt === 'number' &&
+    typeof o.endsAt === 'number'
+  );
+}

--- a/mobile/src/services/firebase/focusSession.service.ts
+++ b/mobile/src/services/firebase/focusSession.service.ts
@@ -146,6 +146,31 @@ export function isFocusSessionElapsed(
   return record.endsAt <= nowMs;
 }
 
+export interface FocusCompleteLaunchPlan {
+  /** The record to finalize, or null when there is nothing honest to write. */
+  finalize: ActiveFocusSession | null;
+  /** The focusSessions id to bind the completion surface to, or null. */
+  completedSessionId: string | null;
+}
+
+/**
+ * Pure: decide what a `focus-complete` notification launch should do, given the
+ * persisted active record. Only an elapsed record belonging to this user is
+ * finalized and bound — a missing record (already finalized on an earlier
+ * return), a not-yet-elapsed record (killed mid-block), or another user's record
+ * degrades to "open Focus, bind nothing" (no fabricated completion, no crash).
+ */
+export function planFocusCompleteLaunch(
+  record: ActiveFocusSession | null,
+  userId: string,
+  nowMs: number
+): FocusCompleteLaunchPlan {
+  if (record && record.userId === userId && isFocusSessionElapsed(record, nowMs)) {
+    return { finalize: record, completedSessionId: record.focusSessionId };
+  }
+  return { finalize: null, completedSessionId: null };
+}
+
 // Test-only export.
 export const _FOCUS_SESSION_ACTIVE_KEY = ACTIVE_KEY;
 

--- a/mobile/src/services/notifications.service.ts
+++ b/mobile/src/services/notifications.service.ts
@@ -4,6 +4,7 @@ import * as Device from 'expo-device';
 import { AppState, AppStateStatus, Platform } from 'react-native';
 import { db } from '../config/firebase';
 import { doc, getDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import { FocusCopy } from '../constants/focusContent';
 
 // ==========================================
 // FOREGROUND NOTIFICATION GATE
@@ -141,12 +142,14 @@ export async function savePushTokenToUser(userId: string, pushToken: string): Pr
 }
 
 /**
- * Schedule a local notification (for habit reminders, etc.)
+ * Schedule a local notification (for habit reminders, etc.). `data` is attached
+ * to the notification content so a tap can be deep-link routed by type.
  */
 export async function scheduleLocalNotification(
   title: string,
   body: string,
-  trigger: Notifications.NotificationTriggerInput
+  trigger: Notifications.NotificationTriggerInput,
+  data?: Record<string, unknown>
 ): Promise<string> {
   return await Notifications.scheduleNotificationAsync({
     content: {
@@ -154,9 +157,54 @@ export async function scheduleLocalNotification(
       body,
       sound: true,
       priority: Notifications.AndroidNotificationPriority.HIGH,
+      ...(data ? { data } : {}),
     },
     trigger,
   });
+}
+
+/**
+ * Ensure notification permission, requesting it once if undetermined. Returns
+ * whether notifications are granted. Used by the focus timer to request on
+ * first use; a denial simply means no completion notification (the timer still
+ * works) — callers degrade gracefully.
+ */
+export async function ensureNotificationPermission(): Promise<boolean> {
+  try {
+    const { status } = await Notifications.getPermissionsAsync();
+    if (status === 'granted') return true;
+    const { status: requested } = await Notifications.requestPermissionsAsync();
+    return requested === 'granted';
+  } catch (error) {
+    console.warn('Notification permission check failed (non-fatal):', error);
+    return false;
+  }
+}
+
+/**
+ * Schedule the focus-block completion notification for `endsAt`. The OS owns it,
+ * so it fires whether the app is backgrounded or killed. The data payload deep
+ * links a tap back to the FocusScreen completion surface for that block. Returns
+ * the scheduled id (to cancel later), or null when permission is denied or
+ * scheduling fails — the timer keeps working regardless.
+ */
+export async function scheduleFocusCompletionNotification(
+  focusSessionId: string,
+  endsAt: number
+): Promise<string | null> {
+  const granted = await ensureNotificationPermission();
+  if (!granted) return null;
+  try {
+    return await scheduleLocalNotification(
+      FocusCopy.focusCompleteNotificationTitle,
+      FocusCopy.focusCompleteNotificationBody,
+      { type: Notifications.SchedulableTriggerInputTypes.DATE, date: endsAt },
+      { type: 'focus-complete', focusSessionId, endsAt }
+    );
+  } catch (error) {
+    console.warn('Failed to schedule focus completion notification:', error);
+    return null;
+  }
 }
 
 /**

--- a/mobile/src/services/notifications.service.ts
+++ b/mobile/src/services/notifications.service.ts
@@ -254,6 +254,21 @@ export async function getPermissionsStatus(): Promise<Notifications.Notification
 }
 
 /**
+ * The notification response that launched the app from a cold start (the user
+ * tapped a notification while the app was killed), or null. Used for
+ * cold-launch deep-link routing that the warm/background response listener
+ * cannot catch because it was not yet subscribed.
+ */
+export async function getLastNotificationResponse(): Promise<Notifications.NotificationResponse | null> {
+  try {
+    return await Notifications.getLastNotificationResponseAsync();
+  } catch (error) {
+    console.warn('Failed to read last notification response:', error);
+    return null;
+  }
+}
+
+/**
  * Open device settings for notifications
  */
 export async function openNotificationSettings(): Promise<void> {


### PR DESCRIPTION
## B-3c.2 — Focus timer survives screen-sleep / backgrounding + completion notification deep-link

Makes a focus block survive screen-sleep, backgrounding, and app-kill, and brings a backgrounded/killed block back to the B-3c.1 inline reflection surface via a tapped completion notification. iOS suspends JS timers in the background, so the model is **timestamp + scheduled local notification**, not a background-running JS interval.

Built in the required order: **2a (commits 1–2)** is the screen-sleep bug fix and is independently revertable; **2b (commits 3–4)** adds the notification + cold-launch deep-link on top.

### Commits (each green / bisectable; tsc stays 167)
| # | SHA | What |
|---|-----|------|
| 1 | `49b475d` | `useTimer` timestamp model: `endsAt` is the source of truth; on AppState `active` recompute remaining from the wall clock, completing if `endsAt` passed. pause/resume re-derive `endsAt`. |
| 2 | `291414e` | Persisted active-session record (`focusSession.service` + `useActiveFocusSession`): mint a **stable** focusSessions id at start, persist `endsAt`, finalize the row under that id via `setDoc(merge)` on the warm / reconcile / startup paths. |
| 3 | `7c95f79` | Schedule an OS-owned completion notification at every focus-running start/resume; cancel at every pause / reset / foreground-completion / unmount. Calm copy + brandCopyGuard. |
| 4 | `df8a2f8` | Notification-tap routing (warm/background) + cold-launch reconstruction via `getLastNotificationResponse` → finalize from record → route to the completion surface bound to the id. |

### 2a — how it works
`endsAt` (epoch ms) is set when a running phase begins and is the source of truth; the visible interval is display-only. On return to foreground the hook recomputes remaining from `Date.now()` vs `endsAt`, completing through the **same** `onSessionComplete` path (so the completion surface + row write still happen). The active-session record (AsyncStorage) carries everything to finalize the focusSessions row from persisted data, so **kill/background → reopen reconciles AND persists the session with no notification involved** (commit 1 covers background→reopen via the live reconcile; commit 2's startup sweep covers kill→reopen-into-Focus).

### 2b — schedule/cancel + cold launch
Every schedule point (start, autoStart, startAnother, beginAnother, resume) schedules a DATE-triggered local notification for `endsAt` with data `{ type:'focus-complete', focusSessionId, endsAt }`; every cancel point (pause, all resets, doneForNow/onExit, **foreground natural completion**, early exit/unmount) cancels it — so stopping early leaves no stray notification and a foreground completion never double-fires a toast. Permission is requested on first use; denial degrades gracefully (timer unaffected, no notification). Breaks are never scheduled.

Cold launch reads `getLastNotificationResponse()`, finalizes the elapsed block from its persisted record (stable id, `planFocusCompleteLaunch`), clears the record, and routes to `FocusTimer` bound to that id. Missing / not-yet-elapsed / other-user record → open Focus plain (no fabricated completion, no crash).

### Honesty & contract
- No fabricated `protocolId`/`BrainState`; `focusSessions` stays the target; `stateBefore`/`stateAfter` untouched. An elapsed block is finalized from a **real** persisted record (Option A); a killed-mid-block record (future `endsAt`) is never finalized.
- **B-3c.1 completion surface / `onBlockReflect` NOT altered.** Reaching `session_complete` with a bound id on cold launch is purely additive: a new route param `completedSessionId`, a new `useTimer.completeNow()` that enters `session_complete` **without** re-firing `onSessionComplete`, and seeding the hook's last-finalized id. The BreakPrompt/reflection rendering and the `onBlockReflect(reflectionId, blockId)` write path are unchanged — so the STOP-and-report gate was not tripped.

### Notification copy (brandCopyGuard pass)
Title `Your focus block is complete` / body `Come back when you're ready.` — calm, no urgency, no "time's up", no deficit. Lives in `FocusCopy` (already a brandCopyGuard source); guard passes.

### Verification
- `tsc --noEmit`: **167** errors (unchanged baseline; the 2 remaining touched-area errors — `NotificationContext:159` routine-reminder and `OnboardingFocusScreen:233` — are pre-existing baseline errors, not introduced here).
- Tests: **1303 passing** (+35 vs 1268 baseline). Sole failing suite remains `AuthContext.test.tsx` (react-native-purchases ESM), unchanged.

### Known interaction (documented, out of scope)
NotificationContext's existing foreground consolidation calls `cancelAllNotifications()` on every foreground, which would also drop a *pending* focus-complete notification if the user foregrounds mid-block then backgrounds again. The session **data** is still safe (the live reconcile + persisted record finalize it on the eventual return — 2a); only the OS notification could be lost in that narrow window. Redesigning the global consolidation is out of scope for this PR.

### Device-walk entry points
**2a only (no notification needed):**
- Start a focus block → lock the screen / let it sleep past `endsAt` → reopen: lands on the completion surface, row written.
- Start a block → background the app past `endsAt` → reopen: same.
- Start a block → force-quit past `endsAt` → reopen the app and open Focus: startup sweep finalizes the row.

**2b (notification fire + tap + cold launch):**
- Start a block, background, wait past `endsAt`: notification fires. Tap it (warm/background) → Focus completion surface bound to the block; reflect.
- Force-quit, wait past `endsAt`, tap the notification from cold: app finalizes the row from the record and lands the bound completion surface.
- Stop early (pause / reset / done-for-now) → no notification fires. Natural foreground completion → no stray toast.
- Deny notification permission → timer still works, no notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
