### PR TITLE
B-3c.3: spare the pending focus-complete notification in the foreground consolidation

### DIFF
--- a/mobile/src/context/NotificationContext.tsx
+++ b/mobile/src/context/NotificationContext.tsx
@@ -15,7 +15,7 @@ import { useNotificationPreferences } from '../hooks/useNotificationPreferences'
 import { useToast } from './ToastContext';
 import {
   setForegroundNotificationHandler,
-  cancelAllNotifications,
+  cancelAllScheduledExceptFocusComplete,
   registerAndSaveFCMToken,
   isServerPushEnabled,
   addNotificationResponseListener,
@@ -111,11 +111,14 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
     setup();
   }, [user?.uid]);
 
-  // Foreground consolidation: cancel pending, reschedule future
+  // Foreground consolidation: cancel pending, reschedule future. Spares the
+  // pending focus-complete notification (the OS owns it; the timer relies on it
+  // firing at endsAt) so a mid-block glance at the phone no longer wipes it.
+  // Every other type is cleared exactly as before.
   useEffect(() => {
     const subscription = AppState.addEventListener('change', async (nextState: AppStateStatus) => {
       if (appStateRef.current !== 'active' && nextState === 'active' && user?.uid) {
-        await cancelAllNotifications();
+        await cancelAllScheduledExceptFocusComplete();
         // Only reschedule locally if server push is off
         if (preferences?.allNotificationsEnabled && !serverPush) {
           await scheduleDailyReminder(user.uid);

--- a/mobile/src/services/__tests__/notifications.service.focus.test.ts
+++ b/mobile/src/services/__tests__/notifications.service.focus.test.ts
@@ -13,14 +13,17 @@ const mockGetPerms = jest.fn((): Promise<{ status: string }> =>
 const mockRequestPerms = jest.fn((): Promise<{ status: string }> =>
   Promise.resolve({ status: 'granted' })
 );
+const mockCancelOne = jest.fn((_id: string) => Promise.resolve());
+const mockCancelAll = jest.fn(() => Promise.resolve());
+const mockGetAll = jest.fn((): Promise<unknown[]> => Promise.resolve([]));
 
 jest.mock('expo-notifications', () => ({
   scheduleNotificationAsync: (...a: unknown[]) => mockSchedule(...a),
   getPermissionsAsync: () => mockGetPerms(),
   requestPermissionsAsync: () => mockRequestPerms(),
-  cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
-  cancelAllScheduledNotificationsAsync: jest.fn(() => Promise.resolve()),
-  getAllScheduledNotificationsAsync: jest.fn(() => Promise.resolve([])),
+  cancelScheduledNotificationAsync: (id: string) => mockCancelOne(id),
+  cancelAllScheduledNotificationsAsync: () => mockCancelAll(),
+  getAllScheduledNotificationsAsync: () => mockGetAll(),
   addNotificationReceivedListener: jest.fn(),
   addNotificationResponseReceivedListener: jest.fn(),
   setNotificationHandler: jest.fn(),
@@ -36,6 +39,7 @@ jest.mock('../../config/firebase', () => ({ db: null }));
 import {
   ensureNotificationPermission,
   scheduleFocusCompletionNotification,
+  cancelAllScheduledExceptFocusComplete,
 } from '../notifications.service';
 
 beforeEach(() => {
@@ -45,6 +49,10 @@ beforeEach(() => {
   mockGetPerms.mockResolvedValue({ status: 'granted' });
   mockRequestPerms.mockReset();
   mockRequestPerms.mockResolvedValue({ status: 'granted' });
+  mockCancelOne.mockClear();
+  mockCancelAll.mockClear();
+  mockGetAll.mockReset();
+  mockGetAll.mockResolvedValue([]);
 });
 
 describe('ensureNotificationPermission', () => {
@@ -92,5 +100,26 @@ describe('scheduleFocusCompletionNotification', () => {
     const id = await scheduleFocusCompletionNotification('fs-1', 123);
     expect(id).toBeNull();
     expect(mockSchedule).not.toHaveBeenCalled();
+  });
+});
+
+describe('cancelAllScheduledExceptFocusComplete', () => {
+  it('clears every pending notification except focus-complete (B-3c.3)', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      { identifier: 'rand-focus-id', content: { data: { type: 'focus-complete' } } },
+      { identifier: 'u1-daily-rhythm', content: { data: { type: 'daily_reminder' } } },
+      { identifier: 'habit-reminder-x', content: { data: { type: 'habit-reminder' } } },
+    ]);
+
+    await cancelAllScheduledExceptFocusComplete();
+
+    // Still clears the non-focus types the foreground consolidation owns.
+    expect(mockCancelOne).toHaveBeenCalledWith('u1-daily-rhythm');
+    expect(mockCancelOne).toHaveBeenCalledWith('habit-reminder-x');
+    // Spares the pending focus-complete schedule.
+    expect(mockCancelOne).not.toHaveBeenCalledWith('rand-focus-id');
+    expect(mockCancelOne).toHaveBeenCalledTimes(2);
+    // Never falls back to the blanket cancel that caused the bug.
+    expect(mockCancelAll).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/services/notifications.service.ts
+++ b/mobile/src/services/notifications.service.ts
@@ -222,6 +222,25 @@ export async function cancelAllNotifications(): Promise<void> {
 }
 
 /**
+ * Cancel all PENDING scheduled notifications EXCEPT the focus-block completion
+ * notification(s). Used by the foreground consolidation so a glance at the phone
+ * mid-block (foreground then re-background) no longer wipes the pending
+ * focus-complete schedule, which the OS owns and the timer relies on to fire at
+ * endsAt. Every other type is cleared exactly as cancelAllNotifications() did.
+ *
+ * Follows the existing filter-then-cancel precedent (cancelAllUserNotifications,
+ * syncAllReminders). focus-complete has no stable identifier prefix, so it is
+ * matched by its data payload (data.type === 'focus-complete').
+ */
+export async function cancelAllScheduledExceptFocusComplete(): Promise<void> {
+  const pending = await Notifications.getAllScheduledNotificationsAsync();
+  for (const request of pending) {
+    if (request.content?.data?.type === 'focus-complete') continue;
+    await Notifications.cancelScheduledNotificationAsync(request.identifier);
+  }
+}
+
+/**
  * Get all scheduled notifications
  */
 export async function getAllScheduledNotifications(): Promise<Notifications.NotificationRequest[]> {


### PR DESCRIPTION
## B-3c.3 — Spare the pending focus-complete notification in the foreground consolidation

Fixes one bug from B-3c.2's completion-notification feature. `NotificationContext`'s foreground consolidation called `cancelAllNotifications()` (= `cancelAllScheduledNotificationsAsync`, clears **all** pending schedules) on **every** background→foreground transition. So if the user glanced at their phone mid-focus-block and re-backgrounded, the pending `focus-complete` notification was wiped and silently never fired at `endsAt` (the session data still finalized via B-3c.2's reconcile, but the notification — the whole point — was lost for the median session).

### Fix (Step-0 option (b): cancel-all-EXCEPT focus-complete)
- New `cancelAllScheduledExceptFocusComplete()` in `notifications.service.ts`: enumerates pending via `getAllScheduledNotificationsAsync()` and cancels each request whose `content.data?.type !== 'focus-complete'`. focus-complete has no stable identifier, so it is matched by its data payload. Matches the existing filter-then-cancel precedent (`cancelAllUserNotifications`, `syncAllReminders`).
- The foreground consolidation effect now calls it instead of `cancelAllNotifications()`. The `scheduleDailyReminder` reschedule and everything else in that effect are untouched.

### Scope discipline — only focus-complete clearing changed
Every other type behaves **exactly** as on `e8c1d35`: daily-rhythm, insights-learning, habit-reminder-*, and routine-reminder-* pending schedules are still cancelled on foreground precisely as before; social/milestone notifications fire immediately (`trigger: null`) and are unaffected. The separately-diagnosed pre-existing weakness — those reminders being dropped on foreground and not restored until cold launch / preference change — is **intentionally preserved, not touched** here.

### cancelAllNotifications
`git grep` confirmed `NotificationContext.tsx:118` was its **sole caller**. It is now unused but **left in place** (exported in `notifications.service.ts`) to keep this slice minimal.

### Tests
Regression test added to `notifications.service.focus.test.ts`: given a focus-complete (random id) + daily-rhythm + habit-reminder pending, asserts `cancelScheduledNotificationAsync` IS called for the daily-rhythm and habit-reminder, is NOT called for the focus-complete, and the blanket `cancelAllScheduledNotificationsAsync` is never used.

### Verification
- `tsc --noEmit`: **167** (unchanged baseline; the two pre-existing errors — NotificationContext routine-reminder TS2345, OnboardingFocusScreen:233 'md' — remain; the routine-reminder one shifted to line 162 from a 3-line comment).
- Tests: **1304 passing** (+1 vs 1303). Sole failing suite remains `AuthContext.test.tsx` (ESM), unchanged.

### Commits (green / bisectable)
- `49ace1d` — scoped helper + wire it into the foreground consolidation.
- `1f12dcd` — regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
