### PR TITLE
B-3d UI polish: nav/naming consistency, text-clipping fix, coral correction

### DIFF
--- a/mobile/src/components/ai/AIAssistantFAB.tsx
+++ b/mobile/src/components/ai/AIAssistantFAB.tsx
@@ -120,6 +120,8 @@ export function AIAssistantFAB({ context }: AIAssistantFABProps) {
 const styles = StyleSheet.create({
   fabContainer: {
     position: 'absolute',
+    // Keep bottom/size in sync with FAB_BOTTOM_OFFSET / FAB_HEIGHT in
+    // constants/fabLayout.ts (used to compute scroll clearance on FAB screens).
     bottom: Spacing.xl + 60, // Above tab bar
     right: Spacing.base,
     width: 68,

--- a/mobile/src/constants/fabLayout.ts
+++ b/mobile/src/constants/fabLayout.ts
@@ -1,0 +1,23 @@
+import { Spacing } from './spacing';
+
+/**
+ * Docked Guide FAB geometry + scroll clearance (A3 interim guard, B-3d polish).
+ *
+ * The Guide FAB (components/ai/AIAssistantFAB.tsx) is absolutely positioned,
+ * 68px tall, sitting `Spacing.xl + 60` above the screen bottom — so its top edge
+ * intrudes ~100px into the scroll area and can occlude a bottom CTA/card.
+ * Scroll content on FAB-showing screens pads its bottom by FAB_SCROLL_CLEARANCE
+ * so nothing sits under the FAB.
+ *
+ * Kept in this lightweight module (Spacing only) so screens can import the value
+ * without pulling AIAssistantFAB's heavy dependency tree (chat modal, svg,
+ * gradient). Keep FAB_HEIGHT / FAB_BOTTOM_OFFSET in sync with the FAB's styles.
+ *
+ * Remove (or fold into the layout) when the Guide-pill migration replaces the
+ * docked FAB.
+ */
+export const FAB_HEIGHT = 68;
+export const FAB_BOTTOM_OFFSET = Spacing.xl + 60;
+
+/** FAB footprint into the scroll area, plus a gap, so bottom content clears it. */
+export const FAB_SCROLL_CLEARANCE = Spacing.xl + FAB_HEIGHT + Spacing.md;

--- a/mobile/src/constants/typography.ts
+++ b/mobile/src/constants/typography.ts
@@ -69,12 +69,26 @@ export const Typography = {
 // TEXT STYLE PRESETS
 // Based on Vara Mobile UI Standards v1.0
 // ===========================================
+
+// React Native's `lineHeight` is an ABSOLUTE value (density-independent px), NOT
+// a CSS-style unitless multiplier. Derive it from the font size so the multiplier
+// intent stays visible and the value auto-tracks fontSize if the size changes
+// (mirrors the correct pattern in JournalScreen.tsx: `fontSize * multiplier`).
+// Assigning the bare multiplier (e.g. 1.5) collapsed the line box to ~1.5px and
+// clipped/ghosted text on every consumer — the B-3d clipping bug this fixes.
+//
+// NOTE: these are computed at the BASE font size and do NOT scale under iOS
+// Dynamic Type / allowFontScaling — a pre-existing, app-wide a11y gap tracked as
+// a separate follow-up, out of scope for this fix.
+const lineHeightFor = (fontSize: number, multiplier: number): number =>
+  fontSize * multiplier;
+
 export const TextStyles = {
   // Display - 32px / Semi-Bold (600) - rare, hero only
   display: {
     fontSize: Typography.fontSize['3xl'],
     fontWeight: Typography.fontWeight.semibold,
-    lineHeight: Typography.lineHeight.heading,
+    lineHeight: lineHeightFor(Typography.fontSize['3xl'], Typography.lineHeight.heading),
     letterSpacing: Typography.letterSpacing.tighter,
   },
 
@@ -83,7 +97,7 @@ export const TextStyles = {
   h1: {
     fontSize: Typography.fontSize['2xl'],
     fontWeight: Typography.fontWeight.semibold,
-    lineHeight: Typography.lineHeight.heading,
+    lineHeight: lineHeightFor(Typography.fontSize['2xl'], Typography.lineHeight.heading),
     letterSpacing: Typography.letterSpacing.tight,
   },
 
@@ -92,7 +106,7 @@ export const TextStyles = {
   h2: {
     fontSize: Typography.fontSize.xl,
     fontWeight: Typography.fontWeight.semibold,
-    lineHeight: Typography.lineHeight.heading,
+    lineHeight: lineHeightFor(Typography.fontSize.xl, Typography.lineHeight.heading),
     letterSpacing: Typography.letterSpacing.tight,
   },
 
@@ -101,7 +115,7 @@ export const TextStyles = {
   h3: {
     fontSize: Typography.fontSize.lg,
     fontWeight: Typography.fontWeight.medium,
-    lineHeight: Typography.lineHeight.heading,
+    lineHeight: lineHeightFor(Typography.fontSize.lg, Typography.lineHeight.heading),
     letterSpacing: Typography.letterSpacing.normal,
   },
 
@@ -109,7 +123,7 @@ export const TextStyles = {
   body: {
     fontSize: Typography.fontSize.base,
     fontWeight: Typography.fontWeight.regular,
-    lineHeight: Typography.lineHeight.normal,
+    lineHeight: lineHeightFor(Typography.fontSize.base, Typography.lineHeight.normal),
     letterSpacing: Typography.letterSpacing.normal,
   },
 
@@ -117,7 +131,7 @@ export const TextStyles = {
   bodySmall: {
     fontSize: Typography.fontSize.sm,
     fontWeight: Typography.fontWeight.regular,
-    lineHeight: Typography.lineHeight.normal,
+    lineHeight: lineHeightFor(Typography.fontSize.sm, Typography.lineHeight.normal),
     letterSpacing: Typography.letterSpacing.normal,
   },
 
@@ -125,7 +139,7 @@ export const TextStyles = {
   caption: {
     fontSize: Typography.fontSize.xs,
     fontWeight: Typography.fontWeight.medium,
-    lineHeight: Typography.lineHeight.normal,
+    lineHeight: lineHeightFor(Typography.fontSize.xs, Typography.lineHeight.normal),
     letterSpacing: Typography.letterSpacing.wide,
   },
 
@@ -134,7 +148,7 @@ export const TextStyles = {
   button: {
     fontSize: Typography.fontSize.base,
     fontWeight: Typography.fontWeight.medium,
-    lineHeight: Typography.lineHeight.normal,
+    lineHeight: lineHeightFor(Typography.fontSize.base, Typography.lineHeight.normal),
     letterSpacing: Typography.letterSpacing.normal,
   },
 
@@ -142,7 +156,7 @@ export const TextStyles = {
   nav: {
     fontSize: Typography.fontSize.xs,
     fontWeight: Typography.fontWeight.medium,
-    lineHeight: Typography.lineHeight.normal,
+    lineHeight: lineHeightFor(Typography.fontSize.xs, Typography.lineHeight.normal),
     letterSpacing: Typography.letterSpacing.normal,
   },
 } as const;

--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -27,7 +27,13 @@ const standardHeaderOptions = {
   headerStyle: { backgroundColor: Colors.mistWhite, elevation: 0, shadowOpacity: 0 } as any,
   headerTintColor: Colors.evergreenTeal,
   headerTitleStyle: { fontWeight: '600' as const, color: Colors.softCharcoal },
-  headerBackTitleVisible: false,
+  // A1 (B-3d polish): pushed AppStack screens sit above the tab navigator, whose
+  // route name is "Main" — which iOS was leaking as the back-button label
+  // ("< Main"). `headerBackTitleVisible` is a no-op in React Navigation v7, so it
+  // never suppressed it. Set an explicit generic fallback label instead; screens
+  // with a single, unambiguous parent pillar override this with the pillar name
+  // (e.g. EnergyBrowse → "Energy", FocusRhythms → "Focus").
+  headerBackTitle: 'Back',
 };
 
 // Auth screens
@@ -702,7 +708,9 @@ const MainNavigator = () => {
             ...standardHeaderOptions,
             animation: 'slide_from_right',
             headerShown: true,
-            title: 'Masterclasses',
+            // A2: the Energy entry point says "Learn"; entry and destination must
+            // agree. (Route id stays "Masterclass"; only the visible title changes.)
+            title: 'Learn',
             headerShadowVisible: false,
             showFAB: true,
           })}
@@ -836,6 +844,8 @@ const MainNavigator = () => {
             component={EnergyBrowseListScreen}
             options={stackOpts({
               ...standardHeaderOptions,
+              // Single, unambiguous parent: only reached from the Energy hub.
+              headerBackTitle: 'Energy',
               animation: 'slide_from_right',
               headerShown: true,
               headerShadowVisible: false,
@@ -852,6 +862,8 @@ const MainNavigator = () => {
             component={FocusRhythmsScreen}
             options={stackOpts({
               ...standardHeaderOptions,
+              // Single, unambiguous parent: only reached from the Focus hub.
+              headerBackTitle: 'Focus',
               animation: 'slide_from_right',
               headerShown: true,
               title: 'Focus rhythms',

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -20,6 +20,7 @@ import { SuggestedActionCard } from '../components/dashboard/SuggestedActionCard
 import { InsightCard } from '../components/dashboard/InsightCard';
 import { RoutineCard } from '../components/dashboard/RoutineCard';
 import { InsightsLookbackCard } from '../components/dashboard/InsightsLookbackCard';
+import { FAB_SCROLL_CLEARANCE } from '../constants/fabLayout';
 import { suggestedAction } from '../components/dashboard/suggestedAction';
 import { FirstShiftFooter } from '../components/dashboard/FirstShiftFooter';
 import NudgeCard from '../components/dashboard/NudgeCard';
@@ -306,6 +307,8 @@ const styles = StyleSheet.create({
   scrollContent: {
     paddingHorizontal: Spacing.base,
     paddingVertical: Spacing.lg,
+    // A3: clear the docked Guide FAB so the bottom "Look back" card isn't occluded.
+    paddingBottom: FAB_SCROLL_CLEARANCE,
   },
   header: {
     marginBottom: Spacing.lg,

--- a/mobile/src/screens/Focus/FocusHubScreen.tsx
+++ b/mobile/src/screens/Focus/FocusHubScreen.tsx
@@ -18,6 +18,7 @@ import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 
 import { Colors, Spacing, TextStyles, Typography } from '../../constants';
 import { ROUTES } from '../../navigation/routes';
+import { FAB_SCROLL_CLEARANCE } from '../../constants/fabLayout';
 
 const MIN_TOUCH_TARGET = 48;
 
@@ -81,7 +82,8 @@ const styles = StyleSheet.create({
   content: {
     paddingHorizontal: Spacing.lg,
     paddingTop: Spacing.lg,
-    paddingBottom: Spacing.xl,
+    // A3: clear the docked Guide FAB so the secondary card isn't occluded.
+    paddingBottom: FAB_SCROLL_CLEARANCE,
   },
   title: {
     ...TextStyles.h1,

--- a/mobile/src/screens/PlanScreen.tsx
+++ b/mobile/src/screens/PlanScreen.tsx
@@ -260,7 +260,7 @@ const PlanScreen: React.FC = () => {
     <SafeAreaView style={styles.container} edges={['top']}>
       {/* Header */}
       <View style={styles.header}>
-        <Text style={styles.pageTitle}>Rhythms</Text>
+        <Text style={styles.pageTitle}>Time</Text>
         <Text style={styles.pageSubtitle}>Your habits and routines</Text>
       </View>
 

--- a/mobile/src/screens/Time/RoutinesTab.tsx
+++ b/mobile/src/screens/Time/RoutinesTab.tsx
@@ -41,6 +41,7 @@ import {
 import { FocusCopy, formatSummary } from '../../constants/focusContent';
 import { LoadingSpinner } from '../../components';
 import { RoutineEditor } from '../../components/routines/RoutineEditor';
+import { FAB_SCROLL_CLEARANCE } from '../../constants/fabLayout';
 import {
   TimeOfDaySelector,
   TimeOfDay,
@@ -494,7 +495,8 @@ const styles = StyleSheet.create({
   },
   routineContent: {
     paddingHorizontal: SpacingTokens.lg,
-    paddingBottom: SpacingTokens.xl,
+    // A3: clear the docked Guide FAB so "Build from scratch" isn't occluded.
+    paddingBottom: FAB_SCROLL_CLEARANCE,
   },
   routineCard: {
     backgroundColor: ColorTokens.backgroundSurface,
@@ -621,7 +623,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: SpacingTokens.xl,
     paddingTop: SpacingTokens['2xl'],
-    paddingBottom: SpacingTokens.xl,
+    // A3: clear the docked Guide FAB so the empty-state CTA isn't occluded.
+    paddingBottom: FAB_SCROLL_CLEARANCE,
   },
   emptyEmoji: {
     fontSize: 48,

--- a/mobile/src/screens/Time/components/activityColors.ts
+++ b/mobile/src/screens/Time/components/activityColors.ts
@@ -2,20 +2,23 @@
  * Activity Color Utilities
  * Brand-compliant color mapping for activity icons
  *
- * Per Focus Page Spec Section 4.2:
+ * Brand rule:
  * - Replace all blue icons with color-primary (#1B5E57)
- * - Replace all red icons with color-error (#D97A6E / Soft Coral)
+ * - Coral (#D97A6E) is color-ERROR and is reserved for genuine errors ONLY — it
+ *   is NEVER an activity-icon color (previously red/pink mapped to it, which put
+ *   coral on positive elements like the Gratitude heart).
  * - Never use blue, bright green, pure red, or any off-palette color
  */
 
 import { ColorTokens, ActivityColors } from '../../../constants/designTokens';
 
 /**
- * Maps legacy activity color names to brand-compliant colors
- * Only three colors are allowed per spec:
+ * Maps legacy activity color names to brand-compliant colors.
+ * Allowed activity-icon colors:
  * - primary (Evergreen Teal) - most activities
- * - coral (Soft Coral) - heart/gratitude related
  * - apricot (Golden Apricot) - energy/coffee related
+ * Coral is intentionally absent: it is the error color and must not appear on
+ * activity icons.
  */
 export function getActivityColor(colorName: string): string {
   const colorMap: Record<string, string> = {
@@ -27,9 +30,11 @@ export function getActivityColor(colorName: string): string {
     indigo: ActivityColors.primary,     // Map indigo → primary teal
     purple: ActivityColors.primary,     // Map purple → primary teal
 
-    // Coral mappings (gratitude, heart, love related)
-    red: ActivityColors.coral,          // Map red → soft coral (brand fix)
-    pink: ActivityColors.coral,         // Map pink → soft coral
+    // Warm/affinity legacy names → primary teal. (Previously mapped to coral,
+    // but coral is the ERROR color — never valid on an activity icon, e.g. the
+    // Gratitude heart or "No Screens" now render teal, not coral.)
+    red: ActivityColors.primary,
+    pink: ActivityColors.primary,
 
     // Apricot mappings (energy, warmth, coffee related)
     orange: ActivityColors.apricot,
@@ -68,21 +73,14 @@ export function getActivityColorWithOpacity(colorName: string, opacity: number =
 export function suggestActivityColor(activityName: string): string {
   const lowerName = activityName.toLowerCase();
 
-  // Coral-appropriate activities (gratitude, heart, love)
-  const coralKeywords = [
-    'gratitude', 'love', 'heart', 'appreciation', 'thankful',
-    'compassion', 'kindness', 'affection', 'caring'
-  ];
-
-  // Apricot-appropriate activities (energy, warmth, morning boost)
+  // Apricot-appropriate activities (energy, warmth, morning boost). Warm/affinity
+  // activities (gratitude, heart, love) intentionally have NO special color and
+  // fall through to primary teal — coral is the error color and is never
+  // suggested for an activity.
   const apricotKeywords = [
     'coffee', 'tea', 'energy', 'breakfast', 'morning',
     'wake', 'sunshine', 'warm', 'boost', 'caffeine'
   ];
-
-  if (coralKeywords.some(keyword => lowerName.includes(keyword))) {
-    return 'coral';
-  }
 
   if (apricotKeywords.some(keyword => lowerName.includes(keyword))) {
     return 'apricot';


### PR DESCRIPTION
## B-3d UI polish — nav/naming consistency, text-clipping fix, coral correction

Polish/correction on the now-live four-pillar IA (surfaced by the flag-ON device walk). Base: `main` @ `d500061`. Bisectable commits grouped by category; each independently revertable. **C2 (Journal brain-health copy) is intentionally HELD** — see below.

> Leave merge to you (`--no-ff`); device walk before merge.

### Commits (grouped A / B / C1)
| SHA | Group | What |
|-----|-------|------|
| `50bb883` | **B** clipping | `TextStyles` lineHeight fix |
| `78a4d34` | **A** consistency | back-label + Masterclasses→Learn |
| `5009795` | **A** (isolated) | Rhythms→Time header |
| `6bcd9f7` | **A3** | FAB scroll-inset |
| `ddae937` | **C1** brand | coral removed from activity icons |

### B — text clipping (Step-0 diagnosed, then fixed)
**Root cause (single, shared):** `TextStyles` presets (`constants/typography.ts`) assigned RN's `lineHeight` a **unitless multiplier** (1.3/1.5/…) — but RN `lineHeight` is **absolute px**, so every consumer got a ~1.3–1.75px line box and text clipped/ghosted. The four walk surfaces were exactly the `TextStyles` consumers (Focus hub, Focus rhythms, Energy hub subtitles, Journal empty state).
**Fix:** a `lineHeightFor(fontSize, multiplier)` helper computes the absolute value (keeps the multiplier intent visible, auto-tracks fontSize — mirrors the pattern already correct in `JournalScreen.tsx`). One shared fix resolves all four surfaces + Button.
*Follow-up captured:* line-heights are computed at base size and don't scale under iOS Dynamic Type (pre-existing, app-wide §13 gap) — out of scope here.

### A1 — back-label ("< Main" leak)
Pushed AppStack screens sit above the tab navigator (route name **"Main"**), which iOS showed as the back label. `headerBackTitleVisible` is a **no-op in React Navigation v7** (installed), so it never suppressed it. Fix at the shared source `standardHeaderOptions` → generic **"Back"** fallback, with pillar overrides on the two single-parent screens: **EnergyBrowse → "Energy"**, **FocusRhythms → "Focus"**. Multi-entry screens (FocusTimer/Journal/Masterclass) keep "Back" since their back destination varies.

### A2
- **Masterclasses → "Learn"** (screen title) so entry (Energy "Learn") and destination agree; route id unchanged. Per-item content-type labels (e.g. "Podcast") left as-is.
- **Rhythms → "Time"** (PlanScreen header) to match the Time tab; subtitle "Your habits and routines" kept. **Isolated commit** (`5009795`) so it can be reverted alone.

### A3 — Guide FAB collision (interim guard)
The docked FAB (68px, `Spacing.xl+60` up) occluded the Routines "Build from scratch" CTA. Added `FAB_SCROLL_CLEARANCE` bottom inset to the FAB-showing screens with bottom content: **RoutinesTab** (routines + empty state), **FocusHub** (secondary card), **Dashboard** (the B-3d "Look back" card). Clearance lives in a lightweight `constants/fabLayout.ts` (Spacing only) so screens don't pull the FAB's heavy deps. Interim until the Guide-pill migration.

### C1 — coral on positive elements (brand blocker)
`activityColors.ts` baked in an old spec mapping red/pink icons → **Soft Coral `#D97A6E`**, which is `ColorTokens.error`. Coral is **errors-only**. Recolored at the source and stopped `suggestActivityColor` from returning coral.

**Coral audit — every routine-activity icon that was coral → new token:**
| Activity | Icon | Template(s) | Was | Now |
|---|---|---|---|---|
| Gratitude Practice | heart | morning-mindful, sunday-recharge | coral `#D97A6E` | teal `#1B5E57` |
| No Screens | monitor-off | sleep wind-down | coral `#D97A6E` | teal `#1B5E57` |
| (`pink` key — no live activity) | — | — | coral | teal (preventive) |

Other `softCoral` uses (Delete Account in Settings) are legitimate destructive/error usage — left as-is. (Noted for a *broader, non-routine* color audit later: `GroupsScreen`/`PeopleScreen` have `softCoral` backgrounds — out of C1's routine-icon scope, unverified.)

### C2 — HELD (not in this PR)
The brain-health-led Journal intro copy is **left unchanged** on purpose: the brand voice/CTA docs are being repositioned (brain-health-led → outcomes-led). Rewriting now means rewriting again against the real standard. Captured as a follow-up tied to the voice-doc repositioning.

### Verification
- **tsc 161** throughout (unchanged; the app-wide typography change added no errors).
- **1324 tests passing** (held from baseline), **0 assertion failures**; sole failing suite `AuthContext.test.tsx` (RevenueCat ESM — pre-existing/allowed).

### Device walk (touched screens)
1. **Push any pillar screen** (Focus hub → Set a focus; Focus rhythms; Energy → Regulate/Rest/Fuel; Journal; Learn): back button reads **"< Focus" / "< Energy" / "< Back"**, never "< Main".
2. **Learn** screen title reads "Learn" (not "Masterclasses"); **Time** tab header reads "Time".
3. **No clipped/ghosted text** at default size on: Focus hub "Set a focus" card, Focus rhythms intro, Energy hub Regulate/Rest/Fuel subtitles, Journal empty state.
4. **FAB no longer covers** the Routines "Build from scratch" CTA, the FocusHub secondary card, or the Dashboard "Look back" card (scroll to the very bottom).
5. **Gratitude Practice** heart + **No Screens** icons render **teal**, not coral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
