### PR TITLE
Slice A: launch-critical copy + trial-framing gate

### DIFF
--- a/mobile/src/__tests__/brandCopyGuard.test.ts
+++ b/mobile/src/__tests__/brandCopyGuard.test.ts
@@ -50,6 +50,11 @@ const COPY_SOURCES = [
   // card's user-facing copy; guarded so the rollout can't reintroduce an em dash
   // / optim* in its rendered strings.
   'src/components/dashboard/InsightsLookbackCard.tsx',
+  // Launch conversion surfaces (Slice A). The post-onboarding paywall + the
+  // Create Account screen; guarded so the outcomes-led copy can't regress an em
+  // dash / optim* (and, below, brain-health-led framing).
+  'src/screens/PaywallScreen.tsx',
+  'src/screens/auth/SignupScreen.tsx',
 ];
 
 // U+2014 EM DASH, built via char code so no literal em-dash byte lives in
@@ -109,6 +114,55 @@ describe('Brand copy guard - em-dash + optim*', () => {
           const violations = lines
             .map((line, idx) => ({ line: line.trim(), num: idx + 1 }))
             .filter(({ line }) => re.test(line) && !isAllowlisted(line));
+
+          if (violations.length > 0) {
+            const details = violations
+              .map((v) => `  Line ${v.num}: ${v.line}`)
+              .join('\n');
+            throw new Error(
+              `Found prohibited ${label} in ${relPath}:\n${details}`
+            );
+          }
+        });
+      });
+    });
+  });
+});
+
+// Conversion surfaces (the paywall + Create Account screen) additionally must
+// stay OUTCOMES-LED. The June pivot moved brain health from headline to
+// backbone, so these highest-intent screens must not reintroduce brain-health-
+// led framing. Scoped to just these two files on purpose: a tree-wide "brain
+// health" ban would trip legitimate uses (e.g. brainHealthMapping.ts). Comments
+// are stripped first, so a comment that mentions the retired framing to explain
+// why it was removed does not trip the guard.
+const OUTCOMES_LED_SURFACES = [
+  'src/screens/PaywallScreen.tsx',
+  'src/screens/auth/SignupScreen.tsx',
+];
+
+const RETIRED_POSITIONING_PATTERNS = [
+  { label: 'brain-health-led framing (brain health / brain-health)', re: /brain[-\s]?health/i },
+  { label: 'brain-aligned framing', re: /brain[-\s]?aligned/i },
+  { label: 'brain-as-headline phrasing', re: /how your brain\b|supporting your brain/i },
+];
+
+describe('Conversion surfaces stay outcomes-led (no brain-health-led framing)', () => {
+  OUTCOMES_LED_SURFACES.forEach((relPath) => {
+    const fullPath = path.join(mobileRoot, relPath);
+    if (!fs.existsSync(fullPath)) return;
+
+    describe(relPath, () => {
+      const raw = fs.readFileSync(fullPath, 'utf-8');
+      const lines = stripBlockComments(raw)
+        .split('\n')
+        .map(stripLineComment);
+
+      RETIRED_POSITIONING_PATTERNS.forEach(({ label, re }) => {
+        it(`does not contain ${label}`, () => {
+          const violations = lines
+            .map((line, idx) => ({ line: line.trim(), num: idx + 1 }))
+            .filter(({ line }) => re.test(line));
 
           if (violations.length > 0) {
             const details = violations

--- a/mobile/src/components/checkin/flow/StatePickStepView.tsx
+++ b/mobile/src/components/checkin/flow/StatePickStepView.tsx
@@ -80,7 +80,19 @@ export interface StatePickStepViewProps {
   // situation (the user never picked it), so the recap would be noise there; the
   // situation still keys the feeling copy exactly as in the dashboard flow.
   hideSituationChip?: boolean;
+  // Optional header (title + subtitle) rendered above the read. Used by the
+  // onboarding re-check to acknowledge a practice just happened; the initial
+  // read omits it.
+  title?: string;
+  subtitle?: string;
+  // Override the two section prompts. The re-check softens them ("Your body:" /
+  // "And how it feels:") under its own title; the initial read keeps the full
+  // questions (arousal default below, feeling default = the situation question).
+  arousalPrompt?: string;
+  feelingPrompt?: string;
 }
+
+const DEFAULT_AROUSAL_PROMPT = "How's your body right now?";
 
 export function StatePickStepView({
   situation,
@@ -88,11 +100,19 @@ export function StatePickStepView({
   onBack,
   onClose,
   hideSituationChip = false,
+  title,
+  subtitle,
+  arousalPrompt = DEFAULT_AROUSAL_PROMPT,
+  feelingPrompt,
 }: StatePickStepViewProps) {
   const reduceMotion = useReducedMotion();
   const [arousal, setArousal] = useState<Arousal | null>(null);
 
   const feeling = FEELING_COPY[situation];
+  // The rendered feeling heading: the caller's override (re-check) or the
+  // situation-specific question (initial read). Same value drives the a11y
+  // announce so screen-reader users hear what's on screen.
+  const feelingHeading = feelingPrompt ?? feeling.question;
 
   const handleEnergy = (value: Arousal) => {
     const firstReveal = arousal === null;
@@ -106,7 +126,7 @@ export function StatePickStepView({
     // users aren't stranded by the progressive disclosure. Only on the first
     // reveal — re-tapping energy to change it doesn't re-announce.
     if (firstReveal) {
-      AccessibilityInfo.announceForAccessibility(feeling.question);
+      AccessibilityInfo.announceForAccessibility(feelingHeading);
     }
   };
 
@@ -142,6 +162,17 @@ export function StatePickStepView({
       </View>
 
       <ScrollView contentContainerStyle={styles.scroll}>
+        {/* Optional header (re-check): a title + subtitle that acknowledge a
+            practice just happened. The initial read omits this. */}
+        {!!title && (
+          <View style={styles.headerBlock}>
+            <Text style={styles.headerTitle} accessibilityRole="header">
+              {title}
+            </Text>
+            {!!subtitle && <Text style={styles.headerSubtitle}>{subtitle}</Text>}
+          </View>
+        )}
+
         {/* Situation anchor chip — the chosen situation as a calm, full-width
             Dew Sage chip directly under the nav row, so content reads top-down
             with no marooned middle. Hidden when the situation was pinned for the
@@ -160,7 +191,7 @@ export function StatePickStepView({
 
         {/* Body state — always visible, re-tappable after it's answered. */}
         <Text style={styles.title} testID="checkin-flow-arousal-title">
-          How's your body right now?
+          {arousalPrompt}
         </Text>
         <View style={styles.options}>
           {AROUSAL_OPTIONS.map((option) => {
@@ -186,7 +217,7 @@ export function StatePickStepView({
         {arousal !== null ? (
           <View style={styles.feelingBlock} testID="checkin-flow-feeling-block">
             <Text style={styles.title} testID="checkin-flow-valence-title">
-              {feeling.question}
+              {feelingHeading}
             </Text>
             <View style={styles.options}>
               {feeling.options.map((option) => (
@@ -240,6 +271,20 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.lg,
     paddingTop: Spacing.md,
     paddingBottom: Spacing.xl,
+  },
+  headerBlock: {
+    marginBottom: 24,
+  },
+  headerTitle: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.evergreenTeal,
+    marginBottom: Spacing.sm,
+  },
+  headerSubtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.softCharcoal,
+    lineHeight: Typography.fontSize.base * Typography.lineHeight.normal,
   },
   situationChip: {
     backgroundColor: Colors.dewSage,

--- a/mobile/src/components/checkin/flow/StatePickStepView.tsx
+++ b/mobile/src/components/checkin/flow/StatePickStepView.tsx
@@ -37,6 +37,7 @@ import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { Colors, Spacing, Typography } from '../../../constants';
 import { useReducedMotion } from '../../../hooks/useReducedMotion';
 import type { Arousal, Situation, Valence } from '../../../engine';
+import { StepIndicator } from '../../onboarding/StepIndicator';
 import { FEELING_COPY } from './feelingCopy';
 
 const MIN_TOUCH_TARGET = 48;
@@ -90,6 +91,12 @@ export interface StatePickStepViewProps {
   // questions (arousal default below, feeling default = the situation question).
   arousalPrompt?: string;
   feelingPrompt?: string;
+  // Onboarding progress chrome. When both are provided (the onboarding arrival +
+  // re-check reads), the same thin step bar every other onboarding screen shows
+  // renders at the top so the flow reads continuous. The dashboard check-in omits
+  // them, so no bar renders there.
+  currentStep?: number;
+  totalSteps?: number;
 }
 
 const DEFAULT_AROUSAL_PROMPT = "How's your body right now?";
@@ -104,6 +111,8 @@ export function StatePickStepView({
   subtitle,
   arousalPrompt = DEFAULT_AROUSAL_PROMPT,
   feelingPrompt,
+  currentStep,
+  totalSteps,
 }: StatePickStepViewProps) {
   const reduceMotion = useReducedMotion();
   const [arousal, setArousal] = useState<Arousal | null>(null);
@@ -162,6 +171,14 @@ export function StatePickStepView({
       </View>
 
       <ScrollView contentContainerStyle={styles.scroll}>
+        {/* Onboarding progress bar — only when the caller passes step context
+            (arrival + re-check reads); the dashboard check-in omits it. */}
+        {currentStep != null && totalSteps != null && (
+          <View style={styles.progress} testID="checkin-flow-progress">
+            <StepIndicator currentStep={currentStep} totalSteps={totalSteps} />
+          </View>
+        )}
+
         {/* Optional header (re-check): a title + subtitle that acknowledge a
             practice just happened. The initial read omits this. */}
         {!!title && (
@@ -271,6 +288,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.lg,
     paddingTop: Spacing.md,
     paddingBottom: Spacing.xl,
+  },
+  progress: {
+    marginBottom: Spacing.lg,
   },
   headerBlock: {
     marginBottom: 24,

--- a/mobile/src/components/checkin/flow/__tests__/StatePickStepView.test.tsx
+++ b/mobile/src/components/checkin/flow/__tests__/StatePickStepView.test.tsx
@@ -115,6 +115,17 @@ describe('StatePickStepView — one progressive screen', () => {
     expect(queryByText('How about now?')).toBeNull();
   });
 
+  it('renders the onboarding progress bar only when step context is provided', () => {
+    const withSteps = render(
+      <StatePickStepView situation="just_reset" onSelect={jest.fn()} currentStep={2} totalSteps={9} />
+    );
+    expect(withSteps.getByTestId('checkin-flow-progress')).toBeTruthy();
+
+    // Dashboard check-in (no step context) shows no bar.
+    const noSteps = render(<StatePickStepView situation="just_reset" onSelect={jest.fn()} />);
+    expect(noSteps.queryByTestId('checkin-flow-progress')).toBeNull();
+  });
+
   it('the chosen energy stays re-tappable and can be changed before answering feeling', () => {
     const onSelect = jest.fn();
     const { getByTestId } = render(

--- a/mobile/src/components/checkin/flow/__tests__/StatePickStepView.test.tsx
+++ b/mobile/src/components/checkin/flow/__tests__/StatePickStepView.test.tsx
@@ -85,6 +85,36 @@ describe('StatePickStepView — one progressive screen', () => {
     expect(getByTestId('checkin-flow-arousal-title')).toBeTruthy();
   });
 
+  it('renders the optional header + prompt overrides (re-check variant), keeping the read intact', () => {
+    const { getByTestId, getByText, queryByText } = render(
+      <StatePickStepView
+        situation="just_reset"
+        onSelect={jest.fn()}
+        hideSituationChip
+        title="How about now?"
+        subtitle="No right answer."
+        arousalPrompt="Your body:"
+        feelingPrompt="And how it feels:"
+      />
+    );
+    expect(getByText('How about now?')).toBeTruthy();
+    expect(getByText('No right answer.')).toBeTruthy();
+    expect(getByTestId('checkin-flow-arousal-title').props.children).toBe('Your body:');
+    expect(queryByText("How's your body right now?")).toBeNull();
+    fireEvent.press(getByTestId('checkin-flow-arousal-revved'));
+    expect(getByTestId('checkin-flow-valence-title').props.children).toBe('And how it feels:');
+  });
+
+  it('defaults to the full questions with no header when overrides are absent (initial read)', () => {
+    const { getByTestId, queryByText } = render(
+      <StatePickStepView situation="just_reset" onSelect={jest.fn()} />
+    );
+    expect(getByTestId('checkin-flow-arousal-title').props.children).toBe(
+      "How's your body right now?"
+    );
+    expect(queryByText('How about now?')).toBeNull();
+  });
+
   it('the chosen energy stays re-tappable and can be changed before answering feeling', () => {
     const onSelect = jest.fn();
     const { getByTestId } = render(

--- a/mobile/src/screens/PaywallScreen.test.tsx
+++ b/mobile/src/screens/PaywallScreen.test.tsx
@@ -138,13 +138,22 @@ describe('PaywallScreen', () => {
       expect(await screen.findByText(/Free for 14 days.*Cancel anytime/i)).toBeTruthy();
     });
 
-    it('shows feature list', () => {
+    it('shows the outcomes-led subtitle + feature list (no brain-health-led framing)', () => {
       render(<PaywallScreen />);
-      expect(screen.getByText('AI-powered brain health guidance')).toBeTruthy();
-      expect(screen.getByText('Full audio and content library')).toBeTruthy();
       expect(
-        screen.getByText('Brain-aligned guidance that adapts to how you arrive each day')
+        screen.getByText('Find your focus. Settle your energy. Get your time back.')
       ).toBeTruthy();
+      expect(screen.getByText('AI guidance in service of focus, energy, and time')).toBeTruthy();
+      expect(screen.getByText('Full audio and content library')).toBeTruthy();
+      expect(screen.getByText('A gentle look back at your patterns')).toBeTruthy();
+      expect(
+        screen.getByText('Guidance that meets you where you arrive each day')
+      ).toBeTruthy();
+      // Retired brain-health-led copy is gone.
+      expect(screen.queryByText('AI-powered brain health guidance')).toBeNull();
+      expect(
+        screen.queryByText('Everything Vara offers, built around how your brain actually works.')
+      ).toBeNull();
     });
   });
 

--- a/mobile/src/screens/PaywallScreen.tsx
+++ b/mobile/src/screens/PaywallScreen.tsx
@@ -41,13 +41,15 @@ const FALLBACK_MONTHLY = `${FALLBACK_CURRENCY}${config.monthlyPrice}`;
 const FALLBACK_ANNUAL = `${FALLBACK_CURRENCY}${config.annualPrice}`;
 const FALLBACK_ANNUAL_EQUIVALENT = `${FALLBACK_CURRENCY}${config.annualMonthlyEquivalent}`;
 
-// Feature list
+// Feature list. Outcomes-led (the June pivot): value stated as focus / energy /
+// time and how the guidance meets the user, not brain-health mechanics. The
+// insights line stays a gentle look-back (no surveillance / progress-grading).
 const FEATURES = [
-  'AI-powered brain health guidance',
+  'AI guidance in service of focus, energy, and time',
   'Full audio and content library',
   'Unlimited habits, routines, and reflections',
-  'Detailed insights and progress patterns',
-  'Brain-aligned guidance that adapts to how you arrive each day',
+  'A gentle look back at your patterns',
+  'Guidance that meets you where you arrive each day',
 ];
 
 const PaywallScreen: React.FC = () => {
@@ -191,9 +193,10 @@ const PaywallScreen: React.FC = () => {
             timeline, and legal copy below (shown only when a trial is available). */}
         <Text style={styles.heading}>The full Vara experience</Text>
 
-        {/* Body */}
+        {/* Body — outcomes-led subtitle (focus / energy / time), not brain-health
+            mechanics. */}
         <Text style={styles.body}>
-          Everything Vara offers, built around how your brain actually works.
+          Find your focus. Settle your energy. Get your time back.
         </Text>
 
         {/* Feature List */}

--- a/mobile/src/screens/auth/SignupScreen.tsx
+++ b/mobile/src/screens/auth/SignupScreen.tsx
@@ -264,9 +264,7 @@ const SignupScreen: React.FC<SignupScreenProps> = ({ navigation }) => {
                 resizeMode="cover"
               />
               <Text style={styles.title}>Create Your Account</Text>
-              <Text style={styles.subtitle}>
-                A calm place to begin supporting your brain health
-              </Text>
+              <Text style={styles.subtitle}>A calm place to begin.</Text>
             </View>
 
             {/* Error Banner */}

--- a/mobile/src/screens/onboarding/OnboardingRecheckScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingRecheckScreen.tsx
@@ -23,6 +23,8 @@ import { Colors, Spacing, Typography, Layout } from '../../constants';
 import {
   ONBOARDING_PROTOCOL_TIME_WINDOW,
   ONBOARDING_SITUATION,
+  ONBOARDING_SR_TOTAL_STEPS,
+  onboardingStepNumber,
 } from '../../constants/onboardingStressRecovery';
 import { useAuth } from '../../context/AuthContext';
 import { saveOnboardingStep, saveRecheckShift } from '../../services/firebase/onboardingStressRecovery.service';
@@ -69,6 +71,8 @@ const OnboardingRecheckScreen: React.FC = () => {
       <StatePickStepView
         situation={ONBOARDING_SITUATION}
         hideSituationChip
+        currentStep={onboardingStepNumber('OnboardingRecheck')}
+        totalSteps={ONBOARDING_SR_TOTAL_STEPS}
         title="How about now?"
         subtitle="No right answer. Just notice where you actually are after those two minutes."
         arousalPrompt="Your body:"

--- a/mobile/src/screens/onboarding/OnboardingRecheckScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingRecheckScreen.tsx
@@ -61,12 +61,18 @@ const OnboardingRecheckScreen: React.FC = () => {
     if (user?.uid) void saveOnboardingStep(user.uid, 'OnboardingRecheck');
   }, [user?.uid]);
 
-  // Phase 1 — the two-tap re-check read, identical to the arrival read.
+  // Phase 1 — the two-tap re-check read. Same component as the arrival read, but
+  // reframed so it acknowledges a practice just happened (not a repeat of the
+  // identical question).
   if (!after) {
     return (
       <StatePickStepView
         situation={ONBOARDING_SITUATION}
         hideSituationChip
+        title="How about now?"
+        subtitle="No right answer. Just notice where you actually are after those two minutes."
+        arousalPrompt="Your body:"
+        feelingPrompt="And how it feels:"
         onSelect={setAfter}
       />
     );

--- a/mobile/src/screens/onboarding/OnboardingStateCheckInScreen.tsx
+++ b/mobile/src/screens/onboarding/OnboardingStateCheckInScreen.tsx
@@ -9,8 +9,9 @@
  * five-state readers stay fed.
  *
  * Rendered bare (no OnboardingScaffold), like the Protocol screen: it's an
- * immersive read with its own layout and auto-advances on the second tap, so it
- * doesn't carry the step bar. It still occupies its true position in the arc.
+ * immersive read with its own layout that auto-advances on the second tap. It
+ * still carries the onboarding step bar (passed to StatePickStepView) so the
+ * flow reads continuous with the scaffold screens.
  */
 import React, { useEffect } from 'react';
 import { useNavigation } from '@react-navigation/native';
@@ -20,6 +21,10 @@ import { quadrantToBrainState } from '../../engine/stateBridge';
 import { ONBOARDING_SITUATION } from './onboardingCatalog';
 import type { Arousal, Valence } from '../../engine/types';
 import { useAuth } from '../../context/AuthContext';
+import {
+  ONBOARDING_SR_TOTAL_STEPS,
+  onboardingStepNumber,
+} from '../../constants/onboardingStressRecovery';
 import {
   saveInitialState,
   saveOnboardingStep,
@@ -51,6 +56,8 @@ const OnboardingStateCheckInScreen: React.FC = () => {
     <StatePickStepView
       situation={ONBOARDING_SITUATION}
       hideSituationChip
+      currentStep={onboardingStepNumber('OnboardingStateCheckIn')}
+      totalSteps={ONBOARDING_SR_TOTAL_STEPS}
       onSelect={onSelect}
       onBack={navigation.canGoBack() ? () => navigation.goBack() : undefined}
     />

--- a/mobile/src/screens/onboarding/__tests__/OnboardingRecheckScreen.test.tsx
+++ b/mobile/src/screens/onboarding/__tests__/OnboardingRecheckScreen.test.tsx
@@ -47,6 +47,7 @@ describe('OnboardingRecheckScreen — two-tap read → felt-shift reveal', () =>
   it('phase 1 renders the reframed two-tap read (acknowledges the practice, no shift line yet)', () => {
     const { getByTestId, getByText, queryByText } = render(<OnboardingRecheckScreen />);
     expect(getByText('How about now?')).toBeTruthy();
+    expect(getByTestId('checkin-flow-progress')).toBeTruthy(); // step bar present on the read
     expect(
       getByText('No right answer. Just notice where you actually are after those two minutes.')
     ).toBeTruthy();

--- a/mobile/src/screens/onboarding/__tests__/OnboardingRecheckScreen.test.tsx
+++ b/mobile/src/screens/onboarding/__tests__/OnboardingRecheckScreen.test.tsx
@@ -44,9 +44,15 @@ beforeEach(() => {
 });
 
 describe('OnboardingRecheckScreen — two-tap read → felt-shift reveal', () => {
-  it('phase 1 renders the two-tap read (no shift line yet)', () => {
-    const { getByTestId, queryByText } = render(<OnboardingRecheckScreen />);
-    expect(getByTestId('checkin-flow-arousal-title')).toBeTruthy();
+  it('phase 1 renders the reframed two-tap read (acknowledges the practice, no shift line yet)', () => {
+    const { getByTestId, getByText, queryByText } = render(<OnboardingRecheckScreen />);
+    expect(getByText('How about now?')).toBeTruthy();
+    expect(
+      getByText('No right answer. Just notice where you actually are after those two minutes.')
+    ).toBeTruthy();
+    // Softened section prompt, not the initial read's full question.
+    expect(getByTestId('checkin-flow-arousal-title').props.children).toBe('Your body:');
+    expect(queryByText("How's your body right now?")).toBeNull();
     expect(queryByText(/You went from/)).toBeNull();
   });
 

--- a/mobile/src/screens/onboarding/__tests__/OnboardingStateCheckInScreen.test.tsx
+++ b/mobile/src/screens/onboarding/__tests__/OnboardingStateCheckInScreen.test.tsx
@@ -36,12 +36,14 @@ beforeEach(() => {
 });
 
 describe('OnboardingStateCheckInScreen — two-tap circumplex read', () => {
-  it('renders the two-tap read with the pinned-situation chip hidden', () => {
+  it('renders the two-tap read with the pinned-situation chip hidden + the step bar', () => {
     const { getByTestId, queryByTestId } = render(<OnboardingStateCheckInScreen />);
     expect(getByTestId('checkin-flow-arousal-title')).toBeTruthy();
     expect(queryByTestId('checkin-flow-state-pick-situation')).toBeNull();
     // No five-state chips anymore.
     expect(queryByTestId('brain-state-radio-wired')).toBeNull();
+    // Carries the onboarding progress bar so the flow reads continuous.
+    expect(getByTestId('checkin-flow-progress')).toBeTruthy();
   });
 
   it('bridges revved+hard (Tense) to wired, saves it, and advances to the driver screen', () => {


### PR DESCRIPTION
Launch-critical copy + config fixes surfaced by the fresh-install walk. Deliberately small — copy/chrome only, no visual redesign. **Please merge `--no-ff`.**

## Commits (grouped A1–A5)
- **A1** `f0ed989` — Paywall outcomes-led copy. Subtitle → "Find your focus. Settle your energy. Get your time back." Bullets: "AI-powered brain health guidance" → "AI guidance in service of focus, energy, and time"; "Brain-aligned guidance…" → "Guidance that meets you where you arrive each day"; "Detailed insights and progress patterns" → "A gentle look back at your patterns". Heading + trial logic untouched.
- **A3** `cc2d1a1` — Signup subtitle → "A calm place to begin."
- **A4** `72fce1e` — Re-check reframe. Prop-level copy variant on `StatePickStepView` (same pattern as `hideSituationChip`): the post-practice read now shows "How about now?" / "No right answer. Just notice where you actually are after those two minutes." with softened prompts "Your body:" / "And how it feels:". Initial read unchanged; component stays shared; a11y announce follows the override.
- **A5** `77091eb` — Progress bar on both state-pick reads (arrival + re-check), which rendered bare and were missing the step bar. Dashboard check-in still omits it.
- `a53ff45` — brandCopyGuard extended: paywall + signup added to the em-dash/optim* list, plus a scoped guard that these two conversion surfaces stay outcomes-led (no brain-health framing).

## A2 — TRIAL FRAMING: GATE STOP (no code shipped — this is the key output)
The 14-day-trial framing is **already fully implemented and App-Store-compliant** in `PaywallScreen.tsx`. It calls `Purchases.checkTrialOrIntroductoryPriceEligibility()` per selected plan and, when the Apple ID is **eligible**, renders:
- CTA "Start your 14-day free trial"
- dynamic legal line "Free for 14 days, then {price}. Cancel anytime. Billed automatically unless cancelled before trial ends." (monthly → "$8.99/month", annual → "$79.99/year")
- the `TrialTimeline`

…and fails **safe** to "Subscribe" / "{price}. Cancel anytime." when not eligible (correct — never promise a trial Apple won't grant).

So the device-walk "Subscribe / no trial" is **not a code gap** — eligibility resolved to ineligible/unknown. That's a **console-config** matter for you:
1. **App Store Connect** — each subscription product ($8.99/mo, $79.99/yr) needs an **Introductory Offer** of type *Free Trial*, 14 days, in a state that ships with the build (Ready to Submit/Approved). No intro offer on the product ⇒ eligibility returns not-eligible ⇒ paywall correctly shows "Subscribe".
2. **RevenueCat** — the current Offering must expose the monthly + annual **packages** mapped to those StoreKit products (so `offerings.current.monthly/annual` are non-null).
3. **Sandbox tester** — if the intro IS configured but your test Apple ID already consumed a trial in that subscription group, eligibility is INELIGIBLE (expected). Re-test with a fresh sandbox Apple ID.

No trial copy was faked over a purchase with no trial attached, per the gate.

## Verification
- Full suite: **1349 passed**; sole failure `AuthContext.test.tsx` (RevenueCat ESM, pre-existing/allowed).
- `tsc --noEmit`: **161** (baseline held).

## Device-walk entry points
- Fresh-install onboarding → confirm the arrival read shows the step bar; run the practice → re-check now reads "How about now?" with the step bar → through to the paywall (outcomes-led copy).
- Returning-user pass → confirm the **initial** dashboard check-in read is unchanged ("How's your body right now?", no header, no step bar).
- Paywall: with a trial-eligible sandbox Apple ID, confirm the trial CTA/line appear (validates the A2 console config once set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
