### PR TITLE
Outcomes-led copy: Energy hub + Journal (+ guard extension)

### DIFF
--- a/mobile/src/__tests__/brandCopyGuard.test.ts
+++ b/mobile/src/__tests__/brandCopyGuard.test.ts
@@ -129,16 +129,26 @@ describe('Brand copy guard - em-dash + optim*', () => {
   });
 });
 
-// Conversion surfaces (the paywall + Create Account screen) additionally must
-// stay OUTCOMES-LED. The June pivot moved brain health from headline to
-// backbone, so these highest-intent screens must not reintroduce brain-health-
-// led framing. Scoped to just these two files on purpose: a tree-wide "brain
-// health" ban would trip legitimate uses (e.g. brainHealthMapping.ts). Comments
-// are stripped first, so a comment that mentions the retired framing to explain
-// why it was removed does not trip the guard.
+// Conversion + in-app headline surfaces additionally must stay OUTCOMES-LED.
+// The June pivot moved brain health from headline to backbone, so these
+// highest-intent / hero-copy screens must not reintroduce brain-health-led
+// framing. Scoped to a curated list on purpose: a tree-wide "brain health" ban
+// would trip legitimate BACKBONE education (e.g. brainHealthMapping.ts, the
+// Learn/Masterclass explainer body). These surfaces carry acquisition or
+// in-app *headline/hub/empty-state* copy where leading with "your brain" is the
+// violation; explainer body copy that uses the backbone as the "why" is NOT
+// listed here. Comments are stripped first, so a comment that mentions the
+// retired framing to explain why it was removed does not trip the guard.
 const OUTCOMES_LED_SURFACES = [
   'src/screens/PaywallScreen.tsx',
   'src/screens/auth/SignupScreen.tsx',
+  // In-app pillar/reflection headline surfaces (v2 outcomes-led sweep). The
+  // Energy hub (three-ways cards + Learn/Journal rows), the Journal intro
+  // callout, and the Journal empty state are hub/headline copy, so they hold to
+  // the same no-brain-health-led-framing rule as the conversion screens.
+  'src/screens/Energy/EnergyHubScreen.tsx',
+  'src/screens/JournalScreen.tsx',
+  'src/components/journal/JournalEmptyState.tsx',
 ];
 
 const RETIRED_POSITIONING_PATTERNS = [

--- a/mobile/src/components/journal/JournalEmptyState.tsx
+++ b/mobile/src/components/journal/JournalEmptyState.tsx
@@ -27,7 +27,7 @@ export const JournalEmptyState: React.FC<JournalEmptyStateProps> = ({
         <Ionicons name="journal-outline" size={96} color={Colors.evergreenTeal} />
       </View>
 
-      <Text style={styles.headline}>Every thought matters</Text>
+      <Text style={styles.headline}>A quiet place to reflect</Text>
 
       <Text style={styles.body}>
         {"Capture what's on your mind when you're ready. It only takes a moment."}

--- a/mobile/src/components/journal/__tests__/JournalEmptyState.test.tsx
+++ b/mobile/src/components/journal/__tests__/JournalEmptyState.test.tsx
@@ -35,7 +35,7 @@ describe('JournalEmptyState', () => {
       <JournalEmptyState onStartReflection={jest.fn()} />
     );
 
-    expect(getByText('Every thought matters')).toBeTruthy();
+    expect(getByText('A quiet place to reflect')).toBeTruthy();
     expect(
       getByText(
         "Capture what's on your mind when you're ready. It only takes a moment."

--- a/mobile/src/screens/Energy/EnergyHubScreen.tsx
+++ b/mobile/src/screens/Energy/EnergyHubScreen.tsx
@@ -76,7 +76,7 @@ const SECONDARY_ENTRIES: SecondaryEntry[] = [
     id: 'learn',
     route: 'Masterclass',
     label: 'Learn',
-    descriptor: 'Short lessons on how your brain works.',
+    descriptor: 'Short lessons on why these practices work.',
     icon: 'school-outline',
   },
 ];

--- a/mobile/src/screens/JournalScreen.tsx
+++ b/mobile/src/screens/JournalScreen.tsx
@@ -555,8 +555,8 @@ const JournalScreen: React.FC = () => {
       {/* Highlight Card intro — matches the Sleep Library pattern */}
       <View style={styles.highlightCard}>
         <Text style={styles.highlightText}>
-          Reflection is how your brain makes sense of experience. A few notes
-          here add up to real self-knowledge over time.
+          Putting what's on your mind into words helps you make sense of it. A
+          few notes here add up to real self-knowledge over time.
         </Text>
       </View>
 


### PR DESCRIPTION
Copy-only v2 brand fixes surfaced by the device walk: three in-app strings still led with "your brain" (headline), which the June pivot retired in favor of brain-health-as-backbone. Rewrites lead with the concrete outcome; the guard is extended so they can't silently regress. **Do not merge** (Kyle merges `--no-ff`). Based on `main @ 73ac58c` (#30/#31 still open).

## Step-0 gate — Energy header (diagnosis, no fix)
**Not in the build — no code fix needed.** The Energy watercolor header wiring exists **only on PR #30's branch** (`energy-home-hero-kit`), which is unmerged; `EnergyHubScreen` on `main` has no header and `energyHeader.webp` isn't on `main`. Focus's header is on `main` (PR #29), Home's is on PR #31's branch. Kyle's build (Focus + Home, no Energy) simply didn't include #30. The header is not failing to render; nothing is broken.

## Commits
1. **`035ef4c` fix(copy)** — outcomes-led rewrites:
   - Energy "Learn" row: `"Short lessons on how your brain works."` → `"Short lessons on why these practices work."`
   - Journal intro callout: `"Reflection is how your brain makes sense of experience. A few notes here add up to real self-knowledge over time."` → `"Putting what's on your mind into words helps you make sense of it. A few notes here add up to real self-knowledge over time."`
   - Journal empty-state headline (mild overclaim → calmer): `"Every thought matters"` → `"A quiet place to reflect"`
   - Updates `JournalEmptyState.test.tsx` to the new headline.
2. **`8262fd1` test(brand)** — extend `brandCopyGuard`'s outcomes-led (no-brain-health-led-framing) check from paywall+signup to `EnergyHubScreen.tsx`, `JournalScreen.tsx`, `JournalEmptyState.tsx`. Scoped to headline/hub/empty-state copy only — NOT backbone education body (`brainHealthMapping.ts`, Learn/Masterclass explainers). Teeth-verified: replanting "how your brain works" on the Energy hub fails the guard.

## ⚠️ Report-only flag (item 5) — your decision, not touched
The Learn surface fetches the **"The Resilient Brain"** podcast (`src/hooks/usePodcastFeed.ts` — RSS + fallback title `'The Resilient Brain'`). That's brain-branded content inside a product that demoted brain-health-as-headline. Flagging for a conscious call; **I did not change it** (it's external podcast branding, not our in-app copy).

## Batch-merge overlaps (both trivial)
- `EnergyHubScreen.tsx` is also edited by **PR #30** (header wiring). My change is the L79 `Learn` descriptor; #30 touches imports/JSX/styles — different regions, should auto-merge, but heads-up.
- `JournalEmptyState.tsx` would also be touched by **PR #31's** deferred Commit 3 (icon→SpotIllustration swap); my change is the headline line — different line, no conflict expected.

## Checks
- tsc **161** (baseline), from `mobile/`.
- `brandCopyGuard` **53/53**; `brandCompliance` + Energy/Journal suites green.
- Copy-only: no screen restructure, no FAB, no Time hub, no journal spot art. No em dashes; conditional claims only.

## PENDING — Kyle
- [ ] Energy hub "Learn" + Journal intro/empty-state read outcome-led (brain as backbone, not headline)
- [ ] Guard now catches brain-health-led regressions on these surfaces
- [ ] Decide on the "The Resilient Brain" podcast branding (flagged above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)